### PR TITLE
Update foundry.mdx[Fix Foundry script]

### DIFF
--- a/docs/build/toolchains/foundry.mdx
+++ b/docs/build/toolchains/foundry.mdx
@@ -24,7 +24,12 @@ Just provide the Telos RPC URL and Chain ID when deploying and verifying your co
 
 ``` bash
 
-forge create --rpc-url "https://mainnet.telos.net/evm" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
+forge create --rpc-url https://mainnet.telos.net/evm \
+  --private-key <your_private_key> \
+  src/MyContract.sol:MyContract \
+  --legacy \
+  --verify \
+  --verifier sourcify
 
 ```
 
@@ -32,18 +37,17 @@ forge create --rpc-url "https://mainnet.telos.net/evm" --private-key <your_priva
 
 ``` bash
 
-forge verify-contract \
-    --chain-id 40 \
-    --num-of-optimizations 200 \ 
-    --compiler-version v0.8.10+commit.fc410830 \
-    <the_contract_address> \
-    src/MyToken.sol:MyToken 
+forge verify-contract <the_contract_address> \
+  src/MyContract.sol:MyContract \
+  --chain-id 40 \
+  --verifier sourcify
 
 ```
 
 :::note
 
---num-of-optimizations will default to 0 if not set on verification, while it defaults to 200 if not set on deployment, so make sure you pass --num-of-optimizations 200 if you left the default compilation settings.
+- Since it needs to be deployed on the Telos EVM instead of Ethereum, you need to specify the Telos corresponding validator `sourcify` instead of the default `etherscan`;
+- You need to wait a few minutes to see the verification result.
 
 :::
 
@@ -53,7 +57,12 @@ forge verify-contract \
 
 ``` bash
 
-forge create --rpc-url "https://testnet.telos.net/evm" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
+forge create --rpc-url https://testnet.telos.net/evm \
+  --private-key <your_private_key> \
+  src/MyContract.sol:MyContract \
+  --legacy \
+  --verify \
+  --verifier sourcify
 
 ```
 
@@ -61,16 +70,15 @@ forge create --rpc-url "https://testnet.telos.net/evm" --private-key <your_priva
 
 ``` bash
 
-forge verify-contract \
-    --chain-id 41 \
-    --num-of-optimizations 200 \ 
-    --compiler-version v0.8.10+commit.fc410830 \
-    <the_contract_address> \
-    src/MyToken.sol:MyToken 
+forge verify-contract <the_contract_address> \
+  src/MyContract.sol:MyContract \
+  --chain-id 41 \
+  --verifier sourcify
 
 ```
 :::note
 
---num-of-optimizations will default to 0 if not set on verification, while it defaults to 200 if not set on deployment, so make sure you pass --num-of-optimizations 200 if you left the default compilation settings.
+- Since it needs to be deployed on the Telos EVM instead of Ethereum, you need to specify the Telos corresponding validator `sourcify` instead of the default `etherscan`;
+- You need to wait a few minutes to see the verification result.
 
 :::


### PR DESCRIPTION
## Description

**Adjust Foundry’s deploy and verify scripts to match the Telos EVM chain**

The original deploy and verify scripts will prompt `custom error: EIP-1559 not activated` and `ETHERSCAN_API_KEY must be set` errors when executed, because the contract needs to be deployed on the Telos EVM chain, not Ethereum, so it is necessary to specify the Telos EVM corresponding verifier `sourcify` instead of the default `etherscan`; 

In addition, perhaps Telos EVM does not yet support the `EIP-1559` protocol, so it is necessary to specify the `—legacy` parameter to specify the transaction format before the London hard fork. Otherwise, it will prompt the `EIP-1559 not activated` error; 


## Test scenarios

The updated script passed the test, for example, this transaction is an example of a successful test: https://testnet.teloscan.io/tx/0x57e32321fb4e259dcc6b62b1b6c9788803f5e6a070b6e473cc4edec974fe75c9

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage
-   [x] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
