### PR TITLE
docs: expand Shielded Accounts — independent accounts, key hierarchy, zk-address format, base layer neutrality

### DIFF
--- a/docs/privacy/concepts.mdx
+++ b/docs/privacy/concepts.mdx
@@ -1,0 +1,112 @@
+---
+sidebar_position: 2
+title: Core Concepts
+description: Key concepts behind the Telos Privacy protocol
+---
+
+# Core Concepts
+
+This page explains the fundamental concepts behind Telos Privacy. For full technical details, see the [Developer Reference](./developer/sdk.mdx).
+
+---
+
+## Zero-Knowledge Proofs (zkSNARKs)
+
+Telos Privacy uses **zkSNARKs** (Zero-Knowledge Succinct Non-Interactive Arguments of Knowledge) to verify that a transaction is valid — without revealing anything about it.
+
+Every deposit, transfer, and withdrawal generates a ZK proof that confirms:
+- The sender has sufficient shielded balance
+- The Merkle tree update is correct
+- No double-spending has occurred
+
+The proof is verified on-chain by the Verifier contracts. No transaction can be processed without a valid proof — but the proof reveals nothing about amounts, senders, or recipients.
+
+---
+
+## The Shielded Pool
+
+The shielded pool is a smart contract on Telos EVM that holds all private balances. Inside the pool, tokens are represented as **encrypted notes** in a Merkle tree. The contract stores the tree root and leaf count — but cannot determine which notes belong to which account.
+
+When you deposit tokens, they enter the pool and are associated with your shielded account as encrypted notes. From that point on, all activity (transfers, withdrawals) is invisible to any outside observer.
+
+---
+
+## Shielded Accounts
+
+A shielded account is your identity inside the pool. It is entirely separate from your public EVM address.
+
+Accounts can be created two ways:
+1. **Wallet-derived** — deterministically from your existing EVM wallet signature (convenient, recoverable)
+2. **Independent** — from a standalone mnemonic with no EVM wallet link (maximum privacy)
+
+Your account is controlled by a **spending key** — a secret 256-bit key that never leaves your device. See [Shielded Accounts](./shielded-accounts.mdx) for full details.
+
+---
+
+## Shielded Addresses (zk-addresses)
+
+To receive funds privately, you share a **zk-address** — not your public 0x address. zk-addresses are encoded in base58 format:
+
+```
+5fkW3dXTvA8Kizt1EbuRyjWofuqR4Ud1YTjGgY1r8nGosDeSaUreq6bwfF61jWL
+```
+
+Key properties:
+- A new zk-address can be generated for each incoming transfer
+- Different zk-addresses from the same account **cannot be linked** to each other on-chain
+- Sharing a zk-address does not reveal your spending key or balance
+
+---
+
+## Three Operations
+
+| Operation | What happens |
+|-----------|-------------|
+| **Deposit** | Tokens move from your public wallet into the shielded pool. The deposit amount is visible on-chain at the moment of deposit, but hidden inside the pool thereafter |
+| **Transfer** | Tokens move privately between shielded accounts. Sender, recipient, and amount are never revealed |
+| **Withdrawal** | Tokens move from the shielded pool back to any public address. You can withdraw to a different address than you deposited from |
+
+---
+
+## The Relayer
+
+A **relayer** is an intermediary node that submits transactions to the pool contract on your behalf. The relayer:
+
+- Abstracts gas fees — you pay in the token being transferred, no TLOS needed
+- Builds the Merkle tree proof for each transaction
+- Queues and serialises transactions to the contract
+- **Cannot see** transaction amounts, senders, or recipients
+
+You interact with the relayer via its [REST API](./developer/relayer-api.mdx). In the zkWallet UI, this happens automatically.
+
+---
+
+## Privacy Guarantees
+
+| What is private | What is visible on-chain |
+|----------------|--------------------------|
+| Shielded transfer amounts | Deposit amount (at deposit time) |
+| Shielded transfer recipients | Deposit source address |
+| Internal pool balances | Withdrawal destination address |
+| Linkage between deposits and withdrawals | Withdrawal amount |
+
+For maximum privacy:
+- Use separate addresses for deposits and withdrawals
+- Use an [independent shielded account](./shielded-accounts.mdx#option-2--independent-account-maximum-privacy) with no EVM wallet link
+- Generate a fresh zk-address for each sender
+
+---
+
+## Base Layer Neutrality
+
+The protocol is designed to operate on a neutral base layer. Validators, sequencers, and relayers process transactions normally — they do not need to inspect or censor individual addresses. Privacy is enforced cryptographically at the protocol level.
+
+No participant in the transaction pipeline has visibility into your shielded activity.
+
+---
+
+## Non-Custodial
+
+No third party — including the relayer, Protofire, or the Telos Foundation — can access, freeze, or move your shielded funds. Only the holder of the spending key can initiate transfers or withdrawals.
+
+The protocol is open-source and runs entirely on Telos EVM smart contracts.

--- a/docs/privacy/shielded-accounts.mdx
+++ b/docs/privacy/shielded-accounts.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Shielded Accounts
 description: How shielded accounts and keys work in Telos Privacy
 ---

--- a/docs/privacy/shielded-accounts.mdx
+++ b/docs/privacy/shielded-accounts.mdx
@@ -1,0 +1,126 @@
+---
+sidebar_position: 3
+title: Shielded Accounts
+description: How shielded accounts and keys work in Telos Privacy
+---
+
+# Shielded Accounts
+
+A shielded account is your identity inside the Telos Privacy pool. It is completely separate from your public Telos EVM address and operates using a different key system designed for zero-knowledge proofs.
+
+Accounts never appear unencrypted in any public field. Only the account owner can decrypt their own account state.
+
+---
+
+## Creating a Shielded Account
+
+There are two ways to create a shielded account:
+
+### Option 1 — Wallet-Derived (Recommended for most users)
+
+Your shielded account is derived deterministically from a signature produced by your regular EVM wallet (MetaMask, WalletConnect, etc.).
+
+**Advantages:**
+- No separate seed phrase to manage
+- The same wallet always produces the same shielded account
+- Recover your account on any device by reconnecting the same wallet
+
+**How it works:**
+1. Your wallet signs a specific message (shown in the app)
+2. The signature is used to derive a **spending key**
+3. The spending key is stored locally in your browser — never sent to any server
+
+**Privacy note:** There is a one-time trusted link between your EVM wallet and your shielded account at derivation time. This link is never recorded on-chain — the shielded account cannot be traced back to your wallet address by any on-chain observer.
+
+---
+
+### Option 2 — Independent Account (Maximum privacy)
+
+For users who want no connection whatsoever to an existing EVM wallet, a shielded account can be created from a standalone secret phrase (mnemonic) with no link to any 0x address.
+
+**Advantages:**
+- Completely detached from any EVM identity
+- Maximum privacy — no derivation link of any kind
+
+**How it works:**
+1. Generate a fresh mnemonic (12 or 24 words) independently of any wallet
+2. Derive a spending key from the mnemonic
+3. Use the spending key to initialise your shielded account in the pool
+
+```typescript
+import { deriveSpendingKeyZkBob } from 'zkbob-client-js';
+
+// From an independently generated mnemonic (no EVM wallet involved)
+const mnemonic = 'your twelve word standalone mnemonic phrase goes here';
+const sk = deriveSpendingKeyZkBob(mnemonic);
+```
+
+Store the mnemonic securely — this is the only way to recover an independent account.
+
+---
+
+## Spending Key
+
+The spending key (σ) is the root secret of your shielded account. It is a 256-bit number from which all other account keys are derived:
+
+| Key | Derived From | Purpose |
+|-----|-------------|---------|
+| **Spending key (σ)** | Root secret | Signs transactions, derives all other keys |
+| **Transaction verifier key (A)** | σ × G (JubJub curve) | Verifies transaction signatures |
+| **Intermediate key (η)** | Poseidon hash of A | Derives nullifiers, viewing keys, decrypts notes |
+| **Outgoing viewing key (κ)** | keccak256(η) | Decrypts your own sent transactions |
+
+The spending key is stored locally in your browser. It is **never** transmitted to the relayer or any server. Anyone with access to your spending key can move your shielded funds — keep it private.
+
+---
+
+## Shielded Addresses (zk-addresses)
+
+Your shielded address is what others use to send you private transfers. It is derived from your spending key and is encoded in **base58 format** — it looks nothing like a standard 0x address:
+
+```
+5fkW3dXTvA8Kizt1EbuRyjWofuqR4Ud1YTjGgY1r8nGosDeSaUreq6bwfF61jWL
+```
+
+### Key properties
+
+- **Not fixed** — you generate a new zk-address for each incoming transfer (though reuse is possible)
+- **Unlinkable** — different zk-addresses from the same account cannot be linked to each other on-chain
+- **Owner-only** — only you can confirm that a given zk-address belongs to your account
+- **Share safely** — sharing a zk-address does not reveal your spending key or account balance
+
+For maximum privacy, generate a fresh zk-address for each sender.
+
+---
+
+## Account Recovery
+
+### Wallet-derived accounts
+
+1. Connect the same wallet that created the account
+2. Sign the same derivation message
+3. Your shielded account is restored — balance and history intact
+
+No backup file needed. Your shielded account state lives in the pool contract; the keys are re-derived from your wallet signature.
+
+### Independent accounts
+
+Recover using your standalone mnemonic phrase. Without this mnemonic, the account cannot be recovered — there is no fallback.
+
+---
+
+## Privacy Guarantees
+
+- Your shielded account is **not linked** to your public wallet address on-chain
+- Shielded transfers do not reveal sender, receiver, or amount
+- The pool uses a Merkle tree of encrypted notes — even the pool contract cannot determine which notes belong to which account
+- Different zk-addresses generated from the same account cannot be linked on-chain
+- The relayer never sees spending keys, balances, or transaction counterparties
+
+---
+
+## Base Layer Neutrality
+
+The zkTelos protocol is designed to operate on a neutral base layer. Validators, sequencers, and relayers can process transactions normally without needing to inspect or censor individual addresses — privacy is enforced cryptographically at the protocol level, not by trusting infrastructure operators.
+
+This means no participant in the transaction pipeline has special visibility into your shielded activity.


### PR DESCRIPTION
Expands the Shielded Accounts page with content from zkBob documentation:

- **Two account creation methods**: wallet-derived (existing flow) and independent standalone mnemonic (maximum privacy, no EVM wallet link)
- **Key hierarchy table**: spending key → verifier key → intermediate key → viewing key
- **zk-address format**: base58 encoding, unlinkability, per-transfer address generation
- **Recovery instructions** for both account types
- **Base Layer Neutrality** concept — validators/relayers cannot inspect or censor shielded activity
- Privacy guarantees section expanded