### PR TITLE
fix: make /privacy section root resolve

### DIFF
--- a/docs/privacy/index.mdx
+++ b/docs/privacy/index.mdx
@@ -1,0 +1,9 @@
+---
+id: privacy/index
+title: Privacy
+slug: /privacy/
+---
+
+import Redirect from '@docusaurus/Redirect';
+
+<Redirect to="/privacy/overview/" />


### PR DESCRIPTION
Adds a privacy section root page so https://docs.telos.net/privacy works instead of 404ing.

Current behavior:
- /privacy/overview/ works
- /privacy/ 404s

This PR adds a section root doc at docs/privacy/index.mdx so the section root resolves cleanly.