### PR TITLE
fix: add /privacy root page

### DIFF
--- a/docs/privacy/index.mdx
+++ b/docs/privacy/index.mdx
@@ -1,9 +1,0 @@
----
-id: privacy/index
-title: Privacy
-slug: /privacy/
----
-
-import Redirect from '@docusaurus/Redirect';
-
-<Redirect to="/privacy/overview/" />

--- a/src/pages/privacy/index.js
+++ b/src/pages/privacy/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Redirect from '@docusaurus/Redirect';
+
+export default function PrivacyRoot() {
+  return <Redirect to="/privacy/overview/" />;
+}


### PR DESCRIPTION
Adds a dedicated pages route for /privacy so the section root works reliably while preserving /privacy/overview/.\n\nWhy this PR:\n- /privacy/overview/ exists\n- /privacy/ still does not resolve reliably after the prior docs-only attempt\n- a pages route is the most explicit way to make /privacy work in this Docusaurus setup\n\nBehavior:\n- /privacy/ -> redirects to /privacy/overview/\n- /privacy/overview/ remains unchanged