### PR TITLE
Use /privacy as the privacy overview route

### DIFF
--- a/docs/privacy/overview.mdx
+++ b/docs/privacy/overview.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Telos Privacy
+slug: /privacy/
 description: Private transactions on Telos EVM using zero-knowledge proofs
 ---
 

--- a/src/pages/privacy/index.js
+++ b/src/pages/privacy/index.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Redirect from '@docusaurus/Redirect';
-
-export default function PrivacyRoot() {
-  return <Redirect to="/privacy/overview/" />;
-}


### PR DESCRIPTION
## Summary
- make the Privacy overview doc live at  instead of 
- remove the extra redirect page at 

## Validation
- yarn run v1.22.22
$ docusaurus build

 ------------------------------------------------------------------------------                                                                                                         Update available 3.2.1 → 3.10.0                                                                                                                 To upgrade Docusaurus packages with the latest version, run the                                       following command:                                                     `yarn upgrade @docusaurus/core@latest                          @docusaurus/plugin-content-docs@latest @docusaurus/preset-classic@latest                        @docusaurus/module-type-aliases@latest`                                                                                                      ------------------------------------------------------------------------------ 

[INFO] [en] Creating an optimized production build...
ℹ Compiling Client
ℹ Compiling Server
✔ Client: Compiled successfully in 3.48s
✔ Server: Compiled successfully in 3.30s
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
Done in 12.29s.
