### PR TITLE
docs: update Telos Hardhat guides for Hardhat 3

### DIFF
--- a/docs/build/toolchains/foundry.mdx
+++ b/docs/build/toolchains/foundry.mdx
@@ -24,7 +24,7 @@ Just provide the Telos RPC URL and Chain ID when deploying and verifying your co
 
 ``` bash
 
-forge create --rpc-url "https://mainnet.telos.net/evm" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
+forge create --rpc-url "https://rpc.telos.net" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
 
 ```
 
@@ -53,7 +53,7 @@ forge verify-contract \
 
 ``` bash
 
-forge create --rpc-url "https://testnet.telos.net/evm" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
+forge create --rpc-url "https://rpc.testnet.telos.net" --private-key <your_private_key>  --verify src/MyContract.sol:MyContract
 
 ```
 

--- a/docs/build/toolchains/hardhat.mdx
+++ b/docs/build/toolchains/hardhat.mdx
@@ -2,36 +2,66 @@
 displayed_sidebar: devBar
 hide_table_of_contents: true
 description: >-
-    Quickstart for using Hardhat.
+    Quickstart for using Hardhat 3 with Telos.
 title: "Hardhat"
 ---
 
-Hardhat is an Ethereum development environment for flexible, extensible, and fast smart contract development.
+Hardhat is an Ethereum development environment for compiling, testing, deploying, and verifying EVM smart contracts.
 
-You can use Hardhat to edit, compile, debug, and deploy your smart contracts to Telos.
+## Using Hardhat 3 with Telos
 
-## Using Hardhat with Telos
+Install Hardhat 3 and the Ethers toolbox:
 
-To configure Hardhat to deploy smart contracts to Telos, update your project’s hardhat.config.ts file by adding Telos as a network:
-
+```bash
+npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox-mocha-ethers dotenv
 ```
-networks: {
-    telos_mainnet: {
-        url: "https://rpc.telos.net",
-        accounts: [process.env.TELOS_MAINNET_PRIVATE_KEY],
-        chainId: 40,
+
+Configure Telos in `hardhat.config.ts`:
+
+```ts title="hardhat.config.ts"
+import "dotenv/config";
+import { defineConfig } from "hardhat/config";
+import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
+
+const telosPrivateKey = process.env.TELOS_PRIVATE_KEY;
+const telosTestnetPrivateKey = process.env.TELOS_TESTNET_PRIVATE_KEY;
+
+export default defineConfig({
+  plugins: [hardhatToolboxMochaEthers],
+  solidity: {
+    version: "0.8.28",
+  },
+  networks: {
+    telos: {
+      type: "http",
+      url: "https://rpc.telos.net",
+      chainId: 40,
+      accounts: telosPrivateKey ? [telosPrivateKey] : [],
     },
-    telos_testnet: {
-        url: "https://rpc.testnet.telos.net",
-        accounts: [process.env.TELOS_TESTNET_PRIVATE_KEY],
-        chainId: 41,
+    telosTestnet: {
+      type: "http",
+      url: "https://rpc.testnet.telos.net",
+      chainId: 41,
+      accounts: telosTestnetPrivateKey ? [telosTestnetPrivateKey] : [],
     },
-},
-defaultNetwork: "telos_testnet",
+  },
+});
+```
+
+Use these environment variables for deployment accounts:
+
+```bash title=".env"
+TELOS_TESTNET_PRIVATE_KEY=0xYOUR_TESTNET_PRIVATE_KEY
+TELOS_PRIVATE_KEY=0xYOUR_MAINNET_PRIVATE_KEY
+```
+
+Run scripts with the network name you configured:
+
+```bash
+npx hardhat --network telosTestnet run scripts/deploy.ts
+npx hardhat --network telos run scripts/deploy.ts
 ```
 
 :::info
-
-For a complete guide on how to use Hardhat to deploy and verify contracts on Telos, see [Deploy and Verify Smart Contracts with Hardhat Deploy plugin](/evm/smart-contracts/hardhat_sourcify/).
-
+For a complete guide, see [Deploy and Verify Smart Contracts with Hardhat 3](/evm/smart-contracts/hardhat_sourcify/).
 :::

--- a/docs/evm/indexers/flair.mdx
+++ b/docs/evm/indexers/flair.mdx
@@ -75,9 +75,9 @@ Set a unique namespace, Telos chainId and RPC endpoint in your config. Remember 
       "processingFilterGroup": "default",
       "sources": [
         # Highly-recommended to have at least 1 websocket endpoint
-        "wss://mainnet.telos.net/evm",
+        "wss://rpc.telos.net/evm",
         # You can put multiple endpoints for failover
-        "https://mainnet.telos.net/evm"
+        "https://rpc.telos.net"
       ]
     }
   ]

--- a/docs/evm/smart-contracts/hardhat_sourcify.mdx
+++ b/docs/evm/smart-contracts/hardhat_sourcify.mdx
@@ -4,128 +4,214 @@ displayed_sidebar: devBar
 hide_table_of_contents: true
 ---
 
-# Deploy and Verify Smart Contracts with Hardhat Deploy plugin
+# Deploy and Verify Smart Contracts with Hardhat 3
 
-** Refer to [this](https://github.com/nathanduft44/telos_hardhat_deploy) repository for project setup. **
+Hardhat is a development environment for compiling, testing, deploying, and verifying EVM smart contracts.
 
-Hardhat is a development environment to compile, deploy, test, and debug smart contracts for EVM compatible blockchains.
+This guide shows how to deploy a contract to Telos with **Hardhat 3** and verify it with Sourcify. It uses the current Telos RPC endpoints and the current Hardhat verification plugin. It does not use the legacy `hardhat-deploy` Sourcify task.
 
-This tutorial will cover how to use the [hardhat-deploy plugin](https://github.com/wighawag/hardhat-deploy) and verify deployed contracts on the Telos explorer on mainnet.
+## What you will do
 
-1. Setup Hardhat project with the Hardhat-deploy plug-in
-2. Deploy contracts using the plug-in
-3. Verify the contracts on sourcify
+1. Create a Hardhat 3 project.
+2. Configure Telos mainnet and testnet.
+3. Deploy a `Greeter` contract.
+4. Verify the deployed contract with Sourcify.
 
-### Setup Local Environment
+## Prerequisites
 
-The first step is to set up the local environment. If you are not familiar with how to set up a local hardhat project, refer to [this page](https://hardhat.org/tutorial/setting-up-the-environment.html).
+- Node.js 22 or newer
+- A Telos EVM wallet with TLOS for gas
+- A private key for the network you want to deploy to
 
-1. Add a deploy folder in the primary directory
+:::caution
+Never commit private keys. Store them in `.env`, add `.env` to `.gitignore`, and use a funded testnet wallet while learning.
+:::
 
-Insert the following code block into the deploy folder under filename - deploy.js
+## Create the project
 
-```js title="hardhat_project/deploy/00_deploy_my_contract.js"
-module.exports = async ({ getNamedAccounts, deployments }) => {
-  const { deploy } = deployments;
-  const { deployer } = await getNamedAccounts();
-  await deploy("Greeter", {
-    from: deployer,
-    args: ["Hello"],
-    log: true,
-  });
-};
+```bash
+mkdir telos-hardhat
+cd telos-hardhat
+npm init -y
+npm pkg set type=module
+npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox-mocha-ethers dotenv
 ```
 
-2. Add a blank deployment folder in root directory. The JSON ABI and byte will be pasted here automatically when a deploy command is executed.
+Create these folders:
 
-## Installations
-
-### Package Checklist
-
-** Make sure these packages are included in your package.json list before running a deploy command.**
-
-- @nomiclabs/hardhat-ethers
-- @nomiclabs/hardhat-waffle
-- chai
-- ethereum-waffle
-- ethers
-- hardhat
-- @openzeppelin/contracts
-- dotenv
-
-Run `npm install <package_name>` if any of the above packages are missing.
-
-**Hardhat Plug-in**
-
-```js title="desktop/Basic_hardhat_project"
-npm install -D hardhat-deploy
+```bash
+mkdir contracts scripts
 ```
 
-Import the plug-in in your hardhat.config.js file
+## Configure Telos networks
 
-```js title="/hardhat.config.js"
-require("hardhat-deploy");
-```
+Create `hardhat.config.ts` in the project root:
 
-When taking into account that Hardhat-deploy-ethers is a fork of @nomiclabs/hardhat-ethers, and other plug-ins may have have an hardcoded dependency on @nomiclabs/hardhat-ethers, the best method to install hardhat-deploy-ethers and ensure compatibility is the following:
+```ts title="hardhat.config.ts"
+import "dotenv/config";
+import { defineConfig } from "hardhat/config";
+import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
 
-```js title="/Basic_hardhat_project"
-npm install --save-dev  @nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers ethers
-```
+const telosPrivateKey = process.env.TELOS_PRIVATE_KEY;
+const telosTestnetPrivateKey = process.env.TELOS_TESTNET_PRIVATE_KEY;
 
-Remember to add: `require("@nomiclabs/hardhat-ethers");` at the top of your hardhat.config.js file.
-
-### Deploy
-
-The following is what the Hardhat config file should like:
-
-```js title="/hardhat.config.js"
-require("@nomiclabs/hardhat-waffle");
-require("dotenv").config({ path: ".env" });
-require("hardhat-deploy");
-require("@nomiclabs/hardhat-ethers");
-
-module.exports = {
-  solidity: "0.8.1",
-  defaultNetwork: "telos_testnet",
-  namedAccounts: {
-    deployer: 0,
+export default defineConfig({
+  plugins: [hardhatToolboxMochaEthers],
+  solidity: {
+    version: "0.8.28",
   },
   networks: {
-    telos_testnet: {
-      url: "https://testnet.telos.net/evm",
-      accounts: [process.env.TELOS_TESTNET_PRIVATE_KEY],
+    telos: {
+      type: "http",
+      url: "https://rpc.telos.net",
+      chainId: 40,
+      accounts: telosPrivateKey ? [telosPrivateKey] : [],
+    },
+    telosTestnet: {
+      type: "http",
+      url: "https://rpc.testnet.telos.net",
       chainId: 41,
+      accounts: telosTestnetPrivateKey ? [telosTestnetPrivateKey] : [],
     },
   },
-};
+});
 ```
 
-### Run Deploy command
+Create `.env` and add the private key for the network you will use:
 
-```
-npx hardhat --network telos_testnet deploy
-```
-
-**Output**
-
-```
-deploying "Greeter" (tx: 0xc800f2bfa3ef75768045d885210a8dfc4148ba2f9838f27113d40db7d26e0024)...: deployed at 0x5C94BA8feC1a9FedE0a1Fdd55f2a860Ad97467ce with 496906 gas
+```bash title=".env"
+TELOS_TESTNET_PRIVATE_KEY=0xYOUR_TESTNET_PRIVATE_KEY
+TELOS_PRIVATE_KEY=0xYOUR_MAINNET_PRIVATE_KEY
 ```
 
-### Verify
+Add `.env` to `.gitignore`:
 
-You can easily verify smart contracts with the hardhat deploy sourcify command from the plugin.
+```bash
+printf "\n.env\n" >> .gitignore
+```
 
-` npx hardhat --network telos_testnet sourcify`
+## Add the contract
 
-Console output should result in contract printed and green verification text printed.
+Create `contracts/Greeter.sol`:
 
-Following these steps will enable you to successfully verify the contract.
+```solidity title="contracts/Greeter.sol"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
 
-<img
-    src={require('/static/img/verify.png').default}
-    alt="hardhat"
-    width="70%"
-    height="automatic"
-/>
+contract Greeter {
+    string private greeting;
+
+    constructor(string memory initialGreeting) {
+        greeting = initialGreeting;
+    }
+
+    function greet() public view returns (string memory) {
+        return greeting;
+    }
+}
+```
+
+Compile the contract:
+
+```bash
+npx hardhat compile
+```
+
+Expected result:
+
+```bash
+Compiled 1 Solidity file with solc 0.8.28
+```
+
+## Add the deploy script
+
+Create `scripts/deploy.ts`:
+
+```ts title="scripts/deploy.ts"
+import { network } from "hardhat";
+
+const { ethers } = await network.create();
+
+const greeter = await ethers.deployContract("Greeter", ["Hello, Telos!"]);
+await greeter.waitForDeployment();
+
+console.log(`Greeter deployed to ${await greeter.getAddress()}`);
+```
+
+## Deploy to Telos testnet
+
+Run the deployment script against Telos testnet:
+
+```bash
+npx hardhat --network telosTestnet run scripts/deploy.ts
+```
+
+Expected result:
+
+```bash
+Greeter deployed to 0x...
+```
+
+Save the deployed address. You need it for verification.
+
+To deploy to mainnet instead, use:
+
+```bash
+npx hardhat --network telos run scripts/deploy.ts
+```
+
+## Verify with Sourcify
+
+Verify the testnet deployment:
+
+```bash
+npx hardhat --network telosTestnet verify sourcify DEPLOYED_CONTRACT_ADDRESS "Hello, Telos!"
+```
+
+Verify the mainnet deployment:
+
+```bash
+npx hardhat --network telos verify sourcify DEPLOYED_CONTRACT_ADDRESS "Hello, Telos!"
+```
+
+Replace `DEPLOYED_CONTRACT_ADDRESS` with the address printed by the deployment script.
+
+The constructor arguments passed to `verify sourcify` must exactly match the constructor arguments used during deployment. In this guide, the constructor argument is `"Hello, Telos!"`.
+
+## Check the contract in the explorer
+
+- Mainnet explorer: [https://www.teloscan.io/](https://www.teloscan.io/)
+- Testnet explorer: [https://testnet.teloscan.io/](https://testnet.teloscan.io/)
+
+Paste the deployed address into the explorer search bar. After verification is indexed, the contract source and ABI should be visible on the contract page.
+
+## Telos network reference
+
+| Network | RPC URL | Chain ID | Explorer |
+| --- | --- | --- | --- |
+| Telos mainnet | `https://rpc.telos.net` | `40` | `https://www.teloscan.io/` |
+| Telos testnet | `https://rpc.testnet.telos.net` | `41` | `https://testnet.teloscan.io/` |
+
+## Troubleshooting
+
+### `https://testnet.telos.net/evm` or `https://mainnet.telos.net/evm` returns 404
+
+Those are legacy endpoints. Use the current RPC URLs:
+
+- Mainnet: `https://rpc.telos.net`
+- Testnet: `https://rpc.testnet.telos.net`
+
+### Hardhat cannot find an account
+
+Check that your `.env` file exists, the variable name matches the network, and the private key starts with `0x`.
+
+- `telosTestnet` uses `TELOS_TESTNET_PRIVATE_KEY`
+- `telos` uses `TELOS_PRIVATE_KEY`
+
+### Sourcify says the bytecode does not match
+
+Recompile and verify with the same Solidity version and constructor arguments used for deployment. If you changed compiler settings after deploying, restore the deployment settings before verifying.
+
+### Verification is accepted but the explorer does not show the source immediately
+
+Wait a few minutes and refresh the contract page. Indexing can lag behind the Sourcify response.

--- a/docs/evm/smart-contracts/nft_minter.mdx
+++ b/docs/evm/smart-contracts/nft_minter.mdx
@@ -6,199 +6,177 @@ hide_table_of_contents: true
 
 # ERC721 NFT
 
-This section will explain how to write an NFT minting smart contract that encapsulates all of the logic based on the NFTs you want to mint, followed by hosting images and metadata on decentralized file storage.
+This guide shows how to deploy an ERC721 NFT contract to Telos testnet with Hardhat 3 and the current OpenZeppelin contracts package.
 
-## Setup Local Dev Environment
+## Prerequisites
 
-**Prerequsites** follow this [link](https://hardhat.org/tutorial/setting-up-the-environment.html) NodeJS version 16 or Hardhat is not already installed on your device.
+- Node.js 22 or newer
+- A Telos testnet wallet with testnet TLOS for gas
+- A hosted NFT metadata JSON URI, such as an `ipfs://...` URI
 
 :::caution
-NodeJS version 16 or less is mandatory.
+Never commit private keys. Store them in `.env`, add `.env` to `.gitignore`, and use a funded testnet wallet while learning.
 :::
 
-First, initialize a local project and install Hardhat tools for testing, compiling, and deploying smart contracts.
+## Create the project
 
-Open a terminal and proceed to the directory you want to create an NFT minter.
-
-```
+```bash
 mkdir telos_nft_minter
 cd telos_nft_minter
 npm init -y
-npm install --save-dev hardhat
+npm pkg set type=module
+npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox-mocha-ethers dotenv @openzeppelin/contracts
+mkdir contracts scripts
 ```
 
-## Hardhat Setup Walkthrough
+## Configure Hardhat
 
+Create `hardhat.config.ts`:
+
+```ts title="hardhat.config.ts"
+import "dotenv/config";
+import { defineConfig } from "hardhat/config";
+import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
+
+const telosPrivateKey = process.env.TELOS_PRIVATE_KEY;
+const telosTestnetPrivateKey = process.env.TELOS_TESTNET_PRIVATE_KEY;
+
+export default defineConfig({
+  plugins: [hardhatToolboxMochaEthers],
+  solidity: {
+    version: "0.8.28",
+  },
+  networks: {
+    telos: {
+      type: "http",
+      url: "https://rpc.telos.net",
+      chainId: 40,
+      accounts: telosPrivateKey ? [telosPrivateKey] : [],
+    },
+    telosTestnet: {
+      type: "http",
+      url: "https://rpc.testnet.telos.net",
+      chainId: 41,
+      accounts: telosTestnetPrivateKey ? [telosTestnetPrivateKey] : [],
+    },
+  },
+});
 ```
-npx hardhat
+
+Create `.env` and add your deployment private key:
+
+```bash title=".env"
+TELOS_TESTNET_PRIVATE_KEY=0xYOUR_TESTNET_PRIVATE_KEY
+TELOS_PRIVATE_KEY=0xYOUR_MAINNET_PRIVATE_KEY
 ```
 
-Select "create a sample project" and press "return" to bypass all the questions asked in the terminal. The system will then ask you to install `hardhat-waffle` and `hardhat-ethers`. These are the plug-ins utilized to test and deploy smart contracts.
+Add `.env` to `.gitignore`:
 
-**If not installed then download here**
-
-```
-npm install --save-dev @nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs/hardhat-ethers ethers
-
+```bash
+printf "\n.env\n" >> .gitignore
 ```
 
-### Using the OpenZeppelin contracts Library API
+## Add the ERC721 contract
 
-Benefits: Reusable Solidity components to build custom contracts, contracts are audited, flexible role based permissioning scheme
+Create `contracts/TelosNFTMinter.sol`:
 
-```
-npm install @openzeppelin/contracts
-```
+```solidity title="contracts/TelosNFTMinter.sol"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
 
-## Solidity ERC721 Smart Contract
+import {ERC721URIStorage, ERC721} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
-The first step is to write a smart contract in a .sol file under the contracts folder.
-
-```js title="/contracts/TelosNFTMinter.sol"
-// SPDX-License-Identifier: UNLICENSED
-
-pragma solidity ^0.8.1;
-
-// Imports
-import "hardhat/console.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
-
-// Contract inherits methods from ERC721 Contract OpenZeppelin Library.
 contract TelosNFTMinter is ERC721URIStorage {
-    // Using Counter Method to keep track of token Ids.
-    using Counters for Counters.Counter;
-    Counters.Counter private _tokenIds;
+    uint256 private _nextTokenId;
 
+    constructor() ERC721("TelosNFT", "SURF") {}
 
-    // Pass name and symbol to ERC721 contract.
-    constructor() ERC721 ("TelosNFT", "SURF") {
+    function mintNFT(string memory tokenURI) public returns (uint256) {
+        uint256 tokenId = _nextTokenId;
+        _nextTokenId++;
+
+        _safeMint(msg.sender, tokenId);
+        _setTokenURI(tokenId, tokenURI);
+
+        return tokenId;
     }
-    // Mint function for users to get their NFT.
-    function mintNFT() public {
-        uint newItemId = _tokenIds.current();
-
-        // Mints NFT to the sender using msg.sender global variable
-        _safeMint(msg.sender, newItemId);
-
-        // This sets the NFT metadata put a photo of your favorite pet for now...
-        _setTokenURI(newItemId, "insert JSON url here");
-
-        console.log("#%s NFT has been minted to %s", newItemId, msg.sender);
-
-        // This uses the Counters method inherited by Open Zeppelin library
-        _tokenIds.increment();
-    }
-
 }
 ```
 
-## Setting up a run.js File in Hardhat Project
+This example uses a simple `uint256` counter. Older tutorials may use OpenZeppelin `Counters`, but that utility is not included in current OpenZeppelin Contracts releases.
 
-A run.js file is set up to use a local instance of the blockchain created by Hardhat. This enables developers to test their contracts to ensure they are compiling and the overall dApp runs as intended.
+Compile the contract:
 
-```js title="scripts/run.js"
-const main = async () => {
-  const nftContractFactory = await hre.ethers.getContractFactory(
-    "TelosNFTMinter"
-  );
-  const nftContract = await nftContractFactory.deploy();
-  await nftContract.deployed();
-  console.log("Contract deployed to:", nftContract.address);
-
-  // Call the function.
-  let txn = await nftContract.mintNFT();
-  // Wait for it to be mined.
-  await txn.wait();
-};
-
-const runMain = async () => {
-  try {
-    await main();
-    process.exit(0);
-  } catch (error) {
-    console.log(error);
-    process.exit(1);
-  }
-};
-
-runMain();
+```bash
+npx hardhat compile
 ```
 
-### Deploy on Local Testnet
+## Test deployment locally
 
-```
-npx hardhat run scripts/run.js
-```
+Create `scripts/deploy.ts`:
 
-### Deploy on Telos Testnet
+```ts title="scripts/deploy.ts"
+import { network } from "hardhat";
 
-To deploy on telos_testnet, wallet credentials must be provided to sign the transaction.
+const metadataUri = "ipfs://REPLACE_WITH_YOUR_METADATA_CID";
+const { ethers } = await network.create();
 
-## Setup Deploy.js File in /scripts Folder
+const nft = await ethers.deployContract("TelosNFTMinter");
+await nft.waitForDeployment();
 
-```js title="scripts/deploy.js"
-const main = async () => {
-  const nftContractFactory = await hre.ethers.getContractFactory(
-    "TelosNFTMinter"
-  );
-  const nftContract = await nftContractFactory.deploy();
-  await nftContract.deployed();
-  console.log("Contract deployed to:", nftContract.address);
+const tx = await nft.mintNFT(metadataUri);
+await tx.wait();
 
-  // Call the function.
-  let txn = await nftContract.mintNFT();
-  // wait for contract to be mined .5seconds
-  await txn.wait();
-  console.log("Minted NFT #1");
-};
-
-const runMain = async () => {
-  try {
-    await main();
-    process.exit(0);
-  } catch (error) {
-    console.log(error);
-    process.exit(1);
-  }
-};
-
-runMain();
+console.log(`TelosNFTMinter deployed to ${await nft.getAddress()}`);
+console.log("Minted token 0");
 ```
 
-Follow steps to deploy on telos_testnet
+Run it on the local Hardhat network first:
 
-1. `npm install dotenv` Telos utilizes a dotenv plug-in to load environment variables from .env file.  
-   **Note** .env file contains sensitive information and can be included in .gitignore to follow best practices.
-2. Create a seperate .env file to hide and paste all private keys.
-
-<img
-    src={require('/static/img/dotenv.png').default}
-    alt="nft minter"
-    width="70%"
-    height="automatic"
-/>
-
-3. Open hardhat.config.js file and add the network configuration for telos_testnet.  
-   Make sure to add `require("dotenv").config({ path: ".env" });` at the top of file.  
-   `telos_tesnet rpc = "https://testnet.telos.net/evm"`  
-   `accounts: [process.env.TELOS]`  
-
-```js title="Telos_NFT_MINTER/hardhat.config.js"
-require("@nomiclabs/hardhat-waffle");
-require("dotenv").config({ path: ".env" });
-
-module.exports = {
-  solidity: "0.8.1",
-  networks: {
-    telos_testnet: {
-      url: "https://testnet.telos.net/evm",
-      accounts: [process.env.TELOS_TESTNET_PRIVATEKEY],
-    },
-  },
-};
+```bash
+npx hardhat run scripts/deploy.ts
 ```
 
-run `npx hardhat run scripts/deploy.js --network telos_testnet`
+Expected result:
 
-After completing these steps you will have minted an NFT using hardhat on the Telos Testnet.
+```bash
+TelosNFTMinter deployed to 0x...
+Minted token 0
+```
+
+## Deploy to Telos testnet
+
+Replace `ipfs://REPLACE_WITH_YOUR_METADATA_CID` in `scripts/deploy.ts` with your NFT metadata URI, then deploy:
+
+```bash
+npx hardhat --network telosTestnet run scripts/deploy.ts
+```
+
+To deploy to Telos mainnet, use:
+
+```bash
+npx hardhat --network telos run scripts/deploy.ts
+```
+
+## Verify the contract
+
+Verify the testnet deployment with Sourcify:
+
+```bash
+npx hardhat --network telosTestnet verify sourcify DEPLOYED_CONTRACT_ADDRESS
+```
+
+Verify the mainnet deployment with Sourcify:
+
+```bash
+npx hardhat --network telos verify sourcify DEPLOYED_CONTRACT_ADDRESS
+```
+
+The `TelosNFTMinter` constructor has no arguments, so the verify command only needs the deployed address.
+
+## View the NFT contract
+
+- Testnet explorer: [https://testnet.teloscan.io/](https://testnet.teloscan.io/)
+- Mainnet explorer: [https://www.teloscan.io/](https://www.teloscan.io/)
+
+Paste the deployed contract address into the explorer to inspect transactions, source verification, and token activity.

--- a/docs/evm/smart-contracts/truffle.mdx
+++ b/docs/evm/smart-contracts/truffle.mdx
@@ -137,14 +137,14 @@ var PrivateKeyProvider = require("truffle-privatekey-provider");
 var privateKey = "private key"; // NOTE: Only use a Dev Wallet with Telos testnet otherwise in production or with real value use .env file and make sure to add .env to gitignore it so its not commited into github.
 var provider = new PrivateKeyProvider(
   privateKey,
-  "https://testnet.telos.net/evm"
+  "https://rpc.testnet.telos.net"
 );
 
 module.exports = {
   networks: {
     telos_testnet: {
       provider: () =>
-        new PrivateKeyProvider(privateKey, `https://testnet.telos.net/evm`),
+        new PrivateKeyProvider(privateKey, `https://rpc.testnet.telos.net`),
       network_id: 41, // Ropsten's id
     },
   },

--- a/docs/evm/smart-contracts/verify_with_remix.mdx
+++ b/docs/evm/smart-contracts/verify_with_remix.mdx
@@ -144,4 +144,4 @@ Get the Contract Address we just deployed in the Deploy Tab
 
 We just verified a ERC20 contract using the Remix IDE - Sourcify plug in.
 
-Head over to [Hardhat Sourcify](/evm/smart-contracts/hardhat_sourcify) for an automated method of verifying multiple smart contracts within a larger project dev environement, simutaneously with just one command!
+Head over to [Deploy and Verify Smart Contracts with Hardhat 3](/evm/smart-contracts/hardhat_sourcify/) for a Hardhat-based verification workflow in a larger project environment.

--- a/docs/nodes/non-bp-nodes/tevmc/mainnet-template.mdx
+++ b/docs/nodes/non-bp-nodes/tevmc/mainnet-template.mdx
@@ -176,7 +176,7 @@ sidebar_position: 5
         "debug": true,
         "api_host": "0.0.0.0",
         "api_port": 7000,
-        "remote_endpoint": "https://mainnet.telos.net/evm",
+        "remote_endpoint": "https://rpc.telos.net",
         "signer_account": "rpc.evm",
         "signer_permission": "active",
         "signer_key": "5Jr65kdYmn33C3UabzhmWDm2PuqbRfPuDStts3ZFNSBLM7TqaiL",

--- a/docs/nodes/non-bp-nodes/tevmc/testnet-template.mdx
+++ b/docs/nodes/non-bp-nodes/tevmc/testnet-template.mdx
@@ -171,7 +171,7 @@ sidebar_position: 6
         "debug": true,
         "api_host": "0.0.0.0",
         "api_port": 7000,
-        "remote_endpoint": "https://testnet.telos.net/evm",
+        "remote_endpoint": "https://rpc.testnet.telos.net",
         "signer_account": "rpc.evm",
         "signer_permission": "active",
         "signer_key": "5Jr65kdYmn33C3UabzhmWDm2PuqbRfPuDStts3ZFNSBLM7TqaiL",

--- a/docs/zero/crosschain/read-evm-data-on-native.mdx
+++ b/docs/zero/crosschain/read-evm-data-on-native.mdx
@@ -26,7 +26,7 @@ Once you got the slot index you are looking for you can use a library like ether
 You can use a library like ethers or web3js to call `getStorageAt`.
 
 ```
-const provider = ethers.getDefaultProvider("https://testnet.telos.net/evm");
+const provider = ethers.getDefaultProvider("https://rpc.testnet.telos.net");
 
 const addr =  "0x10b95d422f2c9714c331b1a14829886b0910f55d"; // Our contract address
 const owner_slot = "0x00"; // Our first slot index "owner"
@@ -51,7 +51,7 @@ Request[] public requests;
  
 We can access each member of that array and its properties like so:
 ```
-const provider = ethers.getDefaultProvider("https://testnet.telos.net/evm");
+const provider = ethers.getDefaultProvider("https://rpc.testnet.telos.net");
 
 const addr = "0x10b95d422f2c9714c331b1a14829886b0910f55d";
 


### PR DESCRIPTION
## Summary
- Rewrite the Hardhat Sourcify guide for Hardhat 3, current plugins, TypeScript config, and current Telos RPC URLs
- Update the Hardhat toolchain quickstart and ERC721 NFT tutorial away from legacy Waffle / @nomiclabs packages
- Replace stale Telos EVM RPC endpoints in related docs and fix the Remix guide link text

## Verification
- npm run build
- Tested the Hardhat 3 Greeter example in a temporary project: compile and local deploy passed
- Tested the updated ERC721 example in a temporary project: compile and local deploy/mint passed

## Notes
- Docusaurus build passes, but still reports pre-existing broken links/anchors unrelated to this PR
- npm install reports existing dependency audit warnings on the docs repo dependencies