### PR TITLE
Add Envio to Telos EVM indexers

### DIFF
--- a/docs/evm/indexers/envio.mdx
+++ b/docs/evm/indexers/envio.mdx
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
 # Indexing With Envio
 
-[Envio](https://envio.dev/?utm_source=telos&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index the Telos EVM (chain ID 40) using your own RPC as the data source.
+[Envio](https://envio.dev/?utm_source=telos&utm_medium=partner-docs) is the data layer for blockchain apps. It gives Telos developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index the Telos EVM (chain ID 40) using your own RPC as the data source.
 
 :::info
 See the [**Envio documentation**](https://docs.envio.dev/?utm_source=telos&utm_medium=partner-docs) to get started.

--- a/docs/evm/indexers/envio.mdx
+++ b/docs/evm/indexers/envio.mdx
@@ -35,5 +35,3 @@ See the [**Envio documentation**](https://docs.envio.dev/?utm_source=telos&utm_m
 
 
 [**Read the quickstart**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=telos&utm_medium=partner-docs) to index your first contract on the Telos EVM.
-
-See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=telos&utm_medium=partner-docs).

--- a/docs/evm/indexers/envio.mdx
+++ b/docs/evm/indexers/envio.mdx
@@ -1,0 +1,37 @@
+---
+sidebar_position: 1.5
+displayed_sidebar: devBar
+title: Indexing With Envio
+description: Learn how to index the Telos EVM with Envio
+hide_table_of_contents: true
+---
+
+# Indexing With Envio
+
+[Envio](https://envio.dev/?utm_source=telos&utm_medium=partner-docs) is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Envio's HyperIndex natively supports indexing any EVM chain out of the box, so you can index the Telos EVM (chain ID 40) using your own RPC as the data source.
+
+:::info
+See the [**Envio documentation**](https://docs.envio.dev/?utm_source=telos&utm_medium=partner-docs) to get started.
+:::
+
+## Key Features
+
+### 1. Fast setup:
+
+- Auto-generate an indexer from any verified contract with `pnpx envio init`.
+- Write event handlers in TypeScript, JavaScript, or ReScript.
+- Index the Telos EVM out of the box using your own RPC as the data source.
+
+### 2. Real-time and historical data:
+
+- Reorg support with both real-time and historical data.
+- Historical backfills at 30,000+ events per second.
+- Multichain data aggregation across EVM and non-EVM networks.
+
+### 3. Flexible hosting:
+
+- Managed hosting on Envio Cloud with git-based deploys, monitoring, zero-downtime, and backups.
+- Or self-host your indexer.
+
+
+[**Read the quickstart**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=telos&utm_medium=partner-docs) to index your first contract on the Telos EVM.

--- a/docs/evm/indexers/envio.mdx
+++ b/docs/evm/indexers/envio.mdx
@@ -35,3 +35,5 @@ See the [**Envio documentation**](https://docs.envio.dev/?utm_source=telos&utm_m
 
 
 [**Read the quickstart**](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=telos&utm_medium=partner-docs) to index your first contract on the Telos EVM.
+
+See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=telos&utm_medium=partner-docs).


### PR DESCRIPTION
This adds an Envio page to the Telos EVM indexers section.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Its HyperIndex supports indexing any EVM chain out of the box, so developers can index the Telos EVM (chain ID 40) using their own RPC as the data source. Indexers can be self-hosted or run on the managed Envio Cloud service.

Website: https://envio.dev/
Docs: https://docs.envio.dev/