### PR TITLE
docs(nodes): update BP and node guides for post-Savanna finality

### DIFF
--- a/docs/build/telos-nodes.mdx
+++ b/docs/build/telos-nodes.mdx
@@ -1,23 +1,31 @@
 ---
 displayed_sidebar: devBar
-hide_table_of_contents: true
-description: >-
-    Quickstart to setting up a node on the Telos Network!
+hide_table_of_contents: false
+description: Choose and configure the correct Telos node role.
 title: "Nodes"
 ---
 
-## [Telos EVM Docker](/nodes/non-bp-nodes/tevmc/)
+# Telos Node Quickstart
 
-The Telos EVM Docker lets you easily set up a local EVM node for development.
+Telos Zero nodes run **TelosZero Core**. The same `nodeos` binary can be configured as a private producer/finalizer, vote relay, public API node, State History node, or P2P seed. Start with [Types of Nodes](/nodes/types-of-nodes/) to keep security, storage, and plugin responsibilities separate.
 
-## [Telos EVM Pre-Synced Package](/nodes/non-bp-nodes/telos-evm-pre-synced-node/)
+## Block producer and Savanna finalizer
 
-Starting the sync process for a Telos EVM node from the beginning can take several days and sometimes even weeks depending on the bandwidth and power of the system running the sync process. This pre-synced package should cut your sync time to 1 day or less by pre-syncing much of the chain data and offering it up as a download.
+A post-Savanna BP signs scheduled blocks with a K1 key and finalizer votes with a separate BLS key. Instant finality is part of the normal producer role, not an optional activation step or separate service.
 
-## [Block Producer](/nodes/bp-nodes/setting-up-telos-validator-nodes/)
+1. [Review the producer role](/nodes/bp-nodes/what-is-a-telos-block-producer-node/).
+2. [Install the approved TelosZero Core release](/nodes/bp-nodes/installing-node-software/).
+3. [Configure and register the private producer](/nodes/bp-nodes/setting-up-telos-validator-nodes/).
+4. [Set up, register, verify, rotate, and recover the finalizer](/nodes/bp-nodes/finalizer-setup/).
 
-Learn how to set up and run a block-producing node on Telos. Because Telos is a Delegated Proof Of Stake (DPOS) network, block producers have to be voted into the production schedule. Learn more about DPOS and the [Telos consensus mechanism](/overview/advanced/consensus/).
+## API, SHiP, relay, and exchange nodes
 
-## [Node Providers](/evm/nodes/overview)
+Non-producing nodes do not need BLS keys. Pure API and SHiP nodes outside a BP vote path can leave vote processing disabled; an intermediate vote relay needs positive `vote-threads` but no finalizer key.
 
-View details on node providers [here](/nodes/node_providers).
+- [Run a non-block-producing Telos Zero node](/nodes/non-bp-nodes/run_a_telos_node/)
+- [Upgrade an exchange/API node to TelosZero Core](/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide/)
+- [Review public node providers](/nodes/node_providers/)
+
+## Telos EVM data nodes
+
+Telos EVM RPC and indexing use the Telos consensus/SHiP stream with an EVM execution and history stack. See [telos-reth](/nodes/non-bp-nodes/telos-reth/) and the [Telos EVM Docker controller](/nodes/non-bp-nodes/tevmc/) for those deployment paths.

--- a/docs/nodes/README.mdx
+++ b/docs/nodes/README.mdx
@@ -2,24 +2,30 @@
 id: 'Nodes and Clients'
 displayed_sidebar: devBar
 sidebar_position: 1
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
-A guide to understanding, building, and maintaining nodes on the Telos Blockchain Network
+# Telos Nodes and Clients
 
-Telos uses Antelope platform-specific components and libraries (`nodeos`, `cleos`, `keosd`, `EOSIO.CDT`, and `EOSJS`) to operate blockchain nodes, collect blockchain data, interact with nodes, and build smart contracts.
+Telos Zero nodes run **TelosZero Core**, the Telos-maintained `nodeos` distribution with Savanna instant-finality support. The package also provides `cleos`, `keosd`, and `spring-util`.
 
-All Telos nodes must implement the client service daemon protocol called **nodeos**. It is a product of Antelope.io and is responsible for processing smart contracts, validating transactions, producing blocks, and confirming blocks on the Telos blockchain.
+Every Telos Zero `nodeos` validates the chain, but operators configure different roles:
 
-For **EVM RPC nodes**, Telos uses [telos-reth](/nodes/non-bp-nodes/telos-reth/) — a fork of Reth (Rust Ethereum) — paired with a consensus client that bridges the native layer to the EVM execution layer.
+- **Block producer/finalizer:** publishes scheduled blocks with a K1 key and votes on blocks with a BLS key.
+- **Vote relay/sentry:** isolates private producers and forwards blocks, transactions, and finalizer votes.
+- **API node:** serves chain RPC to applications without production keys.
+- **State History (SHiP) node:** streams block, trace, state, and optional finality data to indexers.
+- **Seed/P2P node:** provides stable entry points to the peer network.
 
-## Node Types
+See [Types of Nodes](/nodes/types-of-nodes/) for role boundaries and [Block Producing Nodes](/nodes/bp-nodes/what-is-a-telos-block-producer-node/) for the post-Savanna producer runbook.
 
-If you are interested in running a Telos node or a Dapp developer, you should consider running a Telos node and understand the differences between validators and block producers. 
+For Telos EVM RPC, Telos uses [telos-reth](/nodes/non-bp-nodes/telos-reth/) with the Telos consensus client. That stack consumes Telos Zero/SHiP data; it does not replace the Telos Zero consensus node.
 
-1. Producing Nodes: Configured for block production. Each active producing node top-21(DPOS) validates all blocks and transactions it receives
+## Operator sources
 
-2. Non-producing Nodes: These nodes verify each block and maintain copies of the blockchain. Non-producing nodes mainly operate in standby mode. At a high level, they do much more than checking and verifying the blockchain in Core consensus, including: 
-    - Proxy, gateway to Blockchain data;
-    - Relaying API calls (API endpoints);
-    - Securing the network and boost RPC call performance.
+- [TelosZero Core releases](https://github.com/telosnetwork/teloszero-core/releases/latest)
+- [Telos node templates, genesis files, and peer files](https://github.com/telosnetwork/node-template)
+- [Live Telos validators and endpoints](https://validators.telos.net/)
+- [Non-BP TelosZero upgrade guide](/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide/)
+
+Always use the tagged release and checksum approved for the target network. Do not select a producer binary solely from the version string returned by a public RPC endpoint.

--- a/docs/nodes/bp-nodes/bp-pay.mdx
+++ b/docs/nodes/bp-nodes/bp-pay.mdx
@@ -5,7 +5,7 @@ description: >-
     Understand how Block Producer
     Pay works and it's sustainable
     scalable model.
-sidebar_position: 5
+sidebar_position: 6
 hide_table_of_contents: true
 ---
 

--- a/docs/nodes/bp-nodes/finalizer-setup.mdx
+++ b/docs/nodes/bp-nodes/finalizer-setup.mdx
@@ -1,0 +1,330 @@
+---
+title: 'Finalizer Setup and Operations'
+displayed_sidebar: devBar
+description: Generate, register, verify, rotate, fail over, and recover Telos Savanna finalizer keys safely.
+sidebar_position: 4
+hide_table_of_contents: false
+---
+
+# Finalizer Setup and Operations
+
+Savanna separates block publishing from finalizer voting. A Telos BP's producer `nodeos` performs both roles:
+
+- the K1 key signs produced blocks;
+- the BLS key signs finalizer votes;
+- a quorum of BLS votes forms the certificate that makes blocks irreversible.
+
+The BLS key is configured as a second `signature-provider`. There is no separate finalizer service.
+
+## Non-negotiable safety rules
+
+1. Generate a unique BLS key for every producer-capable `nodeos` instance.
+2. Never share a BLS private key across hosts, networks, or instances.
+3. Keep `finalizers/safety.dat` on persistent local storage.
+4. Never copy `safety.dat` between hosts or restore an older backup of it.
+5. If `safety.dat` is missing, corrupt, stale, or uncertain for a previously used key, retire that key and activate a never-used key.
+6. Configure and start a node with a replacement key **before** activating that key on-chain.
+7. Never delete the current or last active key as a routine operation. Rotate first and verify the new native policy and votes.
+
+These rules prevent a finalizer from signing conflicting branches with incomplete voting history.
+
+## Initial finalizer setup
+
+### 1. Generate the key on the producer host
+
+Create a protected key directory and generate the BLS key, public key, and proof of possession:
+
+```bash
+sudo install -d -o telos -g telos -m 0700 /var/lib/telos/keys
+
+sudo -u telos sh -c '
+  umask 077
+  key_file=/var/lib/telos/keys/finalizer-mainnet-primary.txt
+  test ! -e "$key_file" || { echo "Refusing to overwrite $key_file" >&2; exit 1; }
+  spring-util bls create key --file "$key_file"
+'
+```
+
+The file contains three values:
+
+```text
+Private key: PVT_BLS_...
+Public key: PUB_BLS_...
+Proof of Possession: SIG_BLS_...
+```
+
+`spring-util bls create key` already creates the proof of possession. Do not pass this three-line file to `spring-util bls create pop`; that command expects a file containing only a raw private key.
+
+Record the public key and proof of possession in the BP's secure operations system. Restrict access to the private key.
+
+### 2. Configure the key and safety directory
+
+Add the BLS provider alongside the existing K1 block-signing provider in `/etc/telos/mainnet-primary/config.ini`:
+
+```ini
+producer-name = <BP_ACCOUNT>
+
+signature-provider = <PUB_K1_BLOCK_KEY>=KEY:<PVT_K1_BLOCK_KEY>
+signature-provider = <PUB_BLS_FINALIZER_KEY>=KEY:<PVT_BLS_FINALIZER_KEY>
+
+vote-threads = 4
+finalizers-dir = /var/lib/telos/finalizers/mainnet-primary
+```
+
+TelosZero's BLS provider uses `KEY`; it is not loaded through `keosd`.
+
+Confirm permissions:
+
+```bash
+sudo chown root:telos /etc/telos/mainnet-primary/config.ini
+sudo chmod 0640 /etc/telos/mainnet-primary/config.ini
+sudo chown telos:telos /var/lib/telos/finalizers/mainnet-primary
+sudo chmod 0700 /var/lib/telos/finalizers/mainnet-primary
+```
+
+On the first start of a never-used BLS key, a missing `safety.dat` is expected. `nodeos` creates and advances it as the key votes. Once used, the key and its complete safety history must remain together on this host.
+
+### 3. Start and sync before registration
+
+```bash
+sudo systemctl restart telos-nodeos@mainnet-primary
+sudo journalctl -u telos-nodeos@mainnet-primary -f
+```
+
+Resolve all key parsing, finalizer directory, P2P, fork, and sync errors before continuing. The node must be running, at head, and connected to vote-capable peers before its first BLS key becomes active.
+
+### 4. Register the producer first
+
+`regfinkey` accepts only a registered producer. Complete [producer registration](/nodes/bp-nodes/setting-up-telos-validator-nodes/#7-register-the-producer) before registering the BLS key.
+
+Run all on-chain key actions from the separate control/signing host, not from the producer host.
+
+### 5. Register the first finalizer key
+
+Set public values on the control host:
+
+```bash
+export RPC=https://mainnet.telos.net
+export BP_ACCOUNT=<BP_ACCOUNT>
+export FINALIZER_PUBLIC_KEY=<PUB_BLS_FINALIZER_KEY>
+export FINALIZER_POP=<SIG_BLS_PROOF_OF_POSSESSION>
+```
+
+Submit `regfinkey` with the BP's account authority:
+
+```bash
+cleos -u "$RPC" push action eosio regfinkey \
+  "$(jq -nc \
+    --arg name "$BP_ACCOUNT" \
+    --arg key "$FINALIZER_PUBLIC_KEY" \
+    --arg pop "$FINALIZER_POP" \
+    '{finalizer_name:$name,finalizer_key:$key,proof_of_possession:$pop}')" \
+  -p "$BP_ACCOUNT@active"
+```
+
+The first registered key for a producer automatically becomes active in the `eosio::finalizers` contract table.
+
+:::warning Do not activate the first key twice
+Do not call `actfinkey` after the first registration. That action is only for switching to a later, already registered key and will reject a key that is already active.
+:::
+
+## Verify registration, policy, and votes
+
+### Contract tables
+
+Find the producer's active key ID and join it to the corresponding registered key:
+
+```bash
+ACTIVE_ID="$(
+  cleos -u "$RPC" get table eosio eosio finalizers --limit 1000 \
+    | jq -r --arg bp "$BP_ACCOUNT" \
+      '.rows[] | select(.finalizer_name == $bp) | .active_key_id'
+)"
+
+cleos -u "$RPC" get table eosio eosio finkeys --limit 1000 \
+  | jq --arg bp "$BP_ACCOUNT" --arg id "$ACTIVE_ID" '
+      .rows[]
+      | select(.finalizer_name == $bp and (.id | tostring) == $id)
+    '
+```
+
+The returned `finalizer_key` must equal `FINALIZER_PUBLIC_KEY`.
+
+`finkeys` includes registered active and standby keys. A row in `finkeys` alone does not prove that the key is active.
+
+### Native finalizer policy and live voting
+
+```bash
+cleos -u "$RPC" get finalizer_info \
+  | jq --arg bp "$BP_ACCOUNT" '{
+      active_generation: .active_finalizer_policy.generation,
+      threshold: .active_finalizer_policy.threshold,
+      active: [
+        .active_finalizer_policy.finalizers[]?
+        | select(.description == $bp)
+      ],
+      pending: [
+        .pending_finalizer_policy.finalizers[]?
+        | select(.description == $bp)
+      ],
+      last_vote: [
+        .last_tracked_votes[]?
+        | select(.description == $bp)
+      ]
+    }'
+```
+
+For an active-schedule BP, verify that:
+
+- the expected public key appears in the active policy;
+- a pending policy appears only during a schedule or key transition;
+- `last_vote[].public_key` matches the active key;
+- `voted_for_block_num` and `voted_for_block_timestamp` advance on repeated checks;
+- the vote's policy generation converges to the active generation;
+- head and irreversible blocks continue advancing.
+
+A registered standby BP will not appear in the native active finalizer policy until it enters the producer schedule.
+
+Monitor chain finality separately:
+
+```bash
+cleos -u "$RPC" get info \
+  | jq '{
+      head_block_num,
+      last_irreversible_block_num,
+      lib_lag: (.head_block_num - .last_irreversible_block_num)
+    }'
+```
+
+Healthy Savanna finality keeps LIB advancing close to head, but operators should not alert on one hard-coded lag value. Alert on sustained deviation from the network baseline, stale votes, or a non-advancing LIB.
+
+## Configure vote relays
+
+Votes travel over the P2P network. Every `nodeos` hop between a private producer and peer finalizers must accept and forward them.
+
+On each intermediate relay/sentry node in that path:
+
+```ini
+plugin = eosio::chain_plugin
+plugin = eosio::net_plugin
+
+vote-threads = 4
+```
+
+A relay needs vote threads but **does not** need a BLS key or `producer-name`.
+
+- Producer nodes default to four vote threads, but this guide sets the value explicitly.
+- Relay nodes must explicitly set a positive value; use `4` unless a tested operator profile says otherwise.
+- Pure API and SHiP nodes outside the vote path can leave vote processing disabled.
+
+Verify bidirectional vote propagation through every firewall, private link, and relay. A successful TCP P2P connection alone does not prove that finalizer votes are reaching peer finalizers.
+
+## Pre-stage a backup producer
+
+Every producer-capable backup host needs its **own** never-shared BLS key and local safety directory.
+
+1. Generate the backup BLS key on the backup host.
+2. Configure only that host with the backup key.
+3. Add `pause-on-startup = true` to the backup's producer configuration so it cannot publish blocks while the primary is running.
+4. Start, sync, and peer the backup node; confirm logs report that production is paused.
+5. Register the backup key with `regfinkey` while the primary key remains active.
+6. Confirm the new key appears in `finkeys` but does not replace `active_key_id`.
+7. Exercise the failover runbook on testnet.
+
+Because the producer already has an active key, registering another key does not activate it.
+
+`pause-on-startup` pauses K1 block production; it does not replace the distinct BLS-key requirement. During failover, activate and verify the backup BLS key, stop the primary producer, remove the startup pause, and restart the backup. Never allow primary and backup hosts to publish blocks with the same K1 key concurrently.
+
+## Rotate a finalizer key
+
+Use this sequence for planned same-host rotation or to activate a pre-staged backup key.
+
+### 1. Prepare and register the replacement
+
+Generate a never-used key on the target host, load it in that host's `signature-provider`, restart, sync, and verify connectivity. Then register it with `regfinkey` as shown above.
+
+### 2. Activate the replacement
+
+```bash
+export NEW_FINALIZER_PUBLIC_KEY=<PUB_BLS_NEW_KEY>
+
+cleos -u "$RPC" push action eosio actfinkey \
+  "$(jq -nc \
+    --arg name "$BP_ACCOUNT" \
+    --arg key "$NEW_FINALIZER_PUBLIC_KEY" \
+    '{finalizer_name:$name,finalizer_key:$key}')" \
+  -p "$BP_ACCOUNT@active"
+```
+
+### 3. Wait for native-policy activation
+
+Do not treat transaction inclusion or the `finalizers` table update as the end of the rotation. Re-run `cleos get finalizer_info` until:
+
+- the new public key has moved through any pending policy into the active policy;
+- tracked votes for the BP use the new key and advance;
+- network finality remains healthy.
+
+For host failover, keep the primary voting until the paused backup is ready, activate the backup key, and verify native-policy activation and votes. Then stop the primary producer, remove `pause-on-startup = true` from the backup, restart it, and verify the exclusive K1 block-production handoff. Never copy the primary's `safety.dat` to the backup.
+
+### 4. Retire the old inactive key
+
+Only after the new key is active and voting may you delete the old, now-inactive registration:
+
+```bash
+export OLD_FINALIZER_PUBLIC_KEY=<PUB_BLS_OLD_KEY>
+
+cleos -u "$RPC" push action eosio delfinkey \
+  "$(jq -nc \
+    --arg name "$BP_ACCOUNT" \
+    --arg key "$OLD_FINALIZER_PUBLIC_KEY" \
+    '{finalizer_name:$name,finalizer_key:$key}')" \
+  -p "$BP_ACCOUNT@active"
+```
+
+Remove the old private provider from the old host when operationally safe. Retain logs and quarantine retired safety state according to the incident-retention policy; never reuse the old BLS key on another host.
+
+## Recover from a missing or corrupt `safety.dat`
+
+If `safety.dat` is missing, corrupt, restored from an older backup, or has uncertain continuity for a previously used BLS key:
+
+1. Stop the affected `nodeos` immediately.
+2. Do not restart voting with that BLS key.
+3. Quarantine the old finalizer directory for investigation; do not copy it to another host.
+4. Generate or select a never-used, pre-registered BLS key.
+5. Configure that key on the recovery host with a fresh local finalizer directory.
+6. Restart from a trusted snapshot if state recovery is required, then fully sync the node with the replacement key loaded. Keep K1 block production paused during a producer-host recovery.
+7. Register the replacement key if needed, then activate it with `actfinkey` from the control host.
+8. Verify the active native policy, advancing votes, head, and LIB.
+9. Delete the retired key registration only after the replacement is active and voting.
+
+A private-key backup by itself is not sufficient recovery state. Reusing that key without its complete voting history can cause unsafe or non-contributing votes.
+
+## Decommission a BP safely
+
+There is no routine standalone "turn off finalizer" action. Coordinate retirement with Telos operators:
+
+1. Ensure the replacement producer/finalizer capacity is active and healthy.
+2. Continue voting until the departing BP is absent from both the producer schedule and native active finalizer policy.
+3. Confirm removal with `cleos get finalizer_info`.
+4. Delete only inactive registered keys.
+5. Remove local BLS providers and securely retire their safety state.
+
+Do not immediately unregister a scheduled producer and delete its current/last key. Contract guards are a last line of defense, not an operating procedure.
+
+## Monitoring checklist
+
+Alert on:
+
+- `nodeos` process exit or repeated restart;
+- unexpected binary/version or checksum drift;
+- stale head or LIB, or sustained LIB lag above the network baseline;
+- a missing BP/key in the active or pending finalizer policy;
+- non-advancing, weak, or missing tracked votes;
+- production pause caused by a lack of recent votes;
+- P2P peer loss on either relay path;
+- missed blocks or handoff failures;
+- finalizer directory permission, disk, checksum, or write errors;
+- clock synchronization drift;
+- unexpected `regfinkey`, `actfinkey`, or `delfinkey` actions.
+
+The [Telos validator dashboard](https://validators.telos.net/) is useful for public-chain and endpoint checks. It does not replace private-host, relay, key-custody, or `safety.dat` monitoring.

--- a/docs/nodes/bp-nodes/installing-node-software.mdx
+++ b/docs/nodes/bp-nodes/installing-node-software.mdx
@@ -1,297 +1,150 @@
 ---
-title: 'Installing Node Software'
+title: 'Install TelosZero Core'
 displayed_sidebar: devBar
-description: >-
-    This section describes all the steps
-    needed to install the software for a
-    Telos Block Producer
+description: Install and verify the supported TelosZero Core software for a Telos block producer.
 sidebar_position: 2
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
-# Installing Node Software
+# Install TelosZero Core
 
-## Installing Leap
+Telos block producers run **TelosZero Core**, the Telos-maintained continuation of Antelope Spring. The package provides the familiar `nodeos`, `cleos`, `keosd`, and `spring-util` commands and includes Savanna instant-finality support.
 
-Leap is a C++ implementation of the Antelope protocol, which Telos is built on. It contains blockchain node software and supporting tools for developers and node operators.
+:::info Post-Savanna guide
+This is the steady-state installation path for a network where Savanna instant finality is already active. It does not cover the one-time Lightspeed/Savanna activation or `switchtosvnn` process.
+:::
 
-Leap currently supports the following operating systems:
-  * Ubuntu 22.04 Jammy
-  * Ubuntu 20.04 Focal
+## Supported release
 
-Other Unix derivatives such as macOS are tended to on a best-effort basis and may not be full featured. If you aren't using Ubuntu, please visit the [Build Unsupported OS](https://github.com/AntelopeIO/leap/blob/main/docs/00_install/01_build-from-source/00_build-unsupported-os.md) page to explore your options.
+The current public production package is:
 
-If you are running an unsupported Ubuntu derivative, such as Linux Mint, you can find the version of Ubuntu your distribution was based on by using this command:
+| Item | Value |
+|---|---|
+| Release | [`teloszero-v1.2.2`](https://github.com/telosnetwork/teloszero-core/releases/tag/teloszero-v1.2.2) |
+| Package | `teloszero-core_1.2.2_amd64.deb` |
+| SHA-256 | `285fdfc1abde5104892d94b1f380c6d79aba35eac3413f139119ea88574c5007` |
+| Release-validated host | Ubuntu 22.04, x86-64 |
+
+Always use a **tagged TelosZero Core release approved for the target Telos network**. Do not deploy the repository's `main` branch or silently substitute a newer release without an operator notice and validation.
+
+The project source also documents Ubuntu 20.04 builds, but the `teloszero-v1.2.2` release notes record the package install smoke test on Ubuntu 22.04. Treat another host OS as an explicitly tested operator exception, not an assumed production target.
+
+## 1. Download and verify the package
 
 ```bash
-cat /etc/upstream-release/lsb-release
+cd /tmp
+curl -fLO https://github.com/telosnetwork/teloszero-core/releases/download/teloszero-v1.2.2/teloszero-core_1.2.2_amd64.deb
+
+echo '285fdfc1abde5104892d94b1f380c6d79aba35eac3413f139119ea88574c5007  teloszero-core_1.2.2_amd64.deb' \
+  | sha256sum --check --strict
 ```
 
-If you are running an unsupported Ubuntu derivative, such as Linux Mint, you can find the version of Ubuntu your distribution was based on by using this command:
+The checksum command must print `OK`. Stop if it does not.
 
-> NOTE: If you are new to EOSIO, it is recommended that you install the EOSIO Prebuilt Binaries. If you are an advanced developer, a block producer, or no binaries are available for your platform, you may need to Build EOSIO from source depending on your OS.
-
-### Binary Installation
-
-This is the fastest way to get started. From the [latest release](https://github.com/AntelopeIO/leap/releases/latest) page, download a binary for one of our [supported operating systems](#supported-operating-systems), or visit the [release tags](https://github.com/AntelopeIO/leap/releases) page to download a binary for a specific version of Leap.
-
-Once you have a `*.deb` file downloaded for your version of Ubuntu, you can install it as follows:
+## 2. Install TelosZero Core
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y ~/Downloads/leap*.deb
+sudo apt-get install -y ./teloszero-core_1.2.2_amd64.deb
 ```
 
-Your download path may vary. If you are in an Ubuntu docker container, omit `sudo` because you run as `root` by default.
+The package conflicts with historical `leap`, `spring`, and `antelope-spring` packages because they install the same command names. `apt` may replace an older package during installation.
 
-Finally, verify Leap was installed correctly:
+Verify the installed binaries:
 
 ```bash
 nodeos --full-version
-```
-You should see a [semantic version](https://semver.org) string followed by a `git` commit hash with no errors. For example:
-
-```
-v3.1.2-0b64f879e3ebe2e4df09d2e62f1fc164cc1125d1
+cleos version client
+spring-util version full
 ```
 
-### Build and Install from Source
+The version may contain a Telos-specific patch suffix when an operator-approved hotfix is deployed. Match the complete version and artifact checksum to the current Telos operator notice; do not infer the approved producer build from a random public RPC endpoint.
 
-You can also build and install Leap from source.
+## 3. Create a dedicated service account and directories
 
-#### Prerequisites
-You will need to build on a [supported operating system](#supported-operating-systems).
+The examples in the BP guides use these paths:
 
-Requirements to build:
-- C++20 compiler and standard library
-- CMake 3.16+
-- LLVM 7 - 11 - for Linux only
-  - newer versions do not work
-- libcurl 7.40.0+
-- git
-- GMP
-- Python 3
-- python3-numpy
-- zlib
+```text
+/etc/telos/mainnet-primary/     configuration
+/var/lib/telos/mainnet-primary/ node data, blocks, and snapshots
+/var/lib/telos/finalizers/mainnet-primary/ finalizer voting safety state
+```
 
-#### Step 1 - Clone
-
-If you don't have the Leap repo cloned to your computer yet, [open a terminal](https://itsfoss.com/open-terminal-ubuntu) and navigate to the folder where you want to clone the Leap repository:
+Create them with restrictive ownership:
 
 ```bash
-cd ~/Downloads
+id -u telos >/dev/null 2>&1 \
+  || sudo useradd --system --home-dir /var/lib/telos --shell /usr/sbin/nologin telos
+
+sudo install -d -o root -g telos -m 0750 /etc/telos/mainnet-primary
+sudo install -d -o telos -g telos -m 0750 /var/lib/telos/mainnet-primary
+sudo install -d -o telos -g telos -m 0700 /var/lib/telos/finalizers/mainnet-primary
 ```
 
-Clone Leap using either HTTPS...
+The instance-specific finalizer directory must be on persistent local storage.
+Never place it on `tmpfs` or a shared filesystem, and never share one directory
+between mainnet, testnet, primary, or backup instances.
+
+## 4. Obtain a current snapshot
+
+A new producer should start from a recent snapshot supplied by a trusted provider and then sync to head through multiple trusted peers.
+
+- [EOS USA Telos snapshots](https://snapshots.eosusa.io/snapshots/telos/)
+- [Telos Unlimited snapshots](https://snapshots.telosunlimited.com/)
+- [EOS Nation snapshots](https://snapshots.eosnation.io/)
+
+Use a provider-published checksum when available. Place the decompressed `.bin` file under `/var/lib/telos/mainnet-primary/snapshots/` and make it readable by the `telos` user.
 
 ```bash
-git clone --recursive https://github.com/AntelopeIO/leap.git
+sudo install -d -o telos -g telos -m 0750 /var/lib/telos/mainnet-primary/snapshots
+sudo chown telos:telos /var/lib/telos/mainnet-primary/snapshots/<snapshot-file>.bin
 ```
 
-...or SSH:
+The Telos mainnet chain ID is:
 
-```bash
-git clone --recursive git@github.com:AntelopeIO/leap.git
+```text
+4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11
 ```
 
-:::note
-**HTTPS vs. SSH Clone**   
-Both an HTTPS or SSH git clone will yield the same result - a folder named `leap` containing our source code. It doesn't matter which type you use.
+Create the producer configuration before starting the snapshot; continue with [Set Up a Telos Block Producer](/nodes/bp-nodes/setting-up-telos-validator-nodes/).
+
+## 5. First start from the snapshot
+
+:::warning Scheduled replacement hosts
+If this host replaces a producer that may still be scheduled, set
+`pause-on-startup = true` before the snapshot import. Do not enable K1 block
+production until the old signer is stopped and fenced. Use a new BLS key and
+fresh local finalizer safety state on the replacement.
 :::
 
-Navigate into that folder:
+After creating `config.ini`, perform the first launch in the foreground:
 
 ```bash
-cd leap
+sudo -u telos /usr/bin/nodeos \
+  --config-dir /etc/telos/mainnet-primary \
+  --data-dir /var/lib/telos/mainnet-primary \
+  --snapshot /var/lib/telos/mainnet-primary/snapshots/<snapshot-file>.bin
 ```
 
-#### Step 2 - Checkout Release Tag or Branch
+Use `--snapshot` only on this first launch. Stop the foreground process cleanly after it has loaded the snapshot, then start the systemd service described in the setup guide without the flag.
 
-Choose which [release](https://github.com/AntelopeIO/leap/releases) or [branch](#branches) you would like to build, then check it out. If you are not sure, use the [latest release](https://github.com/AntelopeIO/leap/releases/latest). For example, if you want to build release 3.1.2 then you would check it out using its tag, `v3.1.2`. In the example below, replace `v0.0.0` with your selected release tag accordingly:
+## Existing producer nodes
 
-```bash
-git fetch --all --tags
-git checkout v0.0.0
-```
+For a normal package update:
 
-Once you are on the branch or release tag you want to build, make sure everything is up-to-date:
+1. Confirm the approved release and checksum.
+2. Stop `nodeos` cleanly.
+3. Preserve the configuration, block log, and the live finalizer directory.
+4. Install the tagged package.
+5. Follow any release-specific replay or snapshot instruction.
+6. Restart and complete every verification check.
 
-```bash
-git pull
-git submodule update --init --recursive
-```
+:::danger Finalizer safety state
+An existing finalizer must retain the complete, current `finalizers/safety.dat` associated with its BLS key. Never restore an older copy, copy it to another host, or reuse the BLS key when this file is missing or uncertain. Follow [Finalizer Setup and Operations](/nodes/bp-nodes/finalizer-setup/#recover-from-a-missing-or-corrupt-safetydat) instead.
+:::
 
-#### Step 3 - Build
+If the node is still running Leap or pre-TelosZero Spring, use the [TelosZero upgrade guide](/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide/) for the package and snapshot-format migration, then return to the BP configuration and finalizer guides.
 
-Select build instructions below for a [pinned build](#pinned-build) (preferred) or an [unpinned build](#unpinned-build).
+## Source builds
 
-**Pinned vs. Unpinned Build**  
-We have two types of builds for Leap: "pinned" and "unpinned." A pinned build is a reproducible build with the build environment and dependency versions fixed by the development team. In contrast, unpinned builds use the dependency versions provided by the build platform. Unpinned builds tend to be quicker because the pinned build environment must be built from scratch. Pinned builds, in addition to being reproducible, ensure the compiler remains the same between builds of different Leap major versions. Leap requires the compiler version to remain the same, otherwise its state might need to be recovered from a portable snapshot or the chain needs to be replayed.
-
-**A Warning On Parallel Compilation Jobs (`-j` flag)**  
-When building C/C++ software, often the build is performed in parallel via a command such as `make -j "$(nproc)"` which uses all available CPU threads. However, be aware that some compilation units (`*.cpp` files) in Leap will consume nearly 4GB of memory. Failures due to memory exhaustion will typically, but not always, manifest as compiler crashes. Using all available CPU threads may also prevent you from doing other things on your computer during compilation. For these reasons, consider reducing this value.
-
-**Docker and `sudo`**
-If you are in an Ubuntu docker container, omit `sudo` from all commands because you run as `root` by default. Most other docker containers also exclude `sudo`, especially Debian-family containers. If your shell prompt is a hash tag (`#`), omit `sudo`.
-
-
-##### Pinned Reproducible Build
-The pinned reproducible build requires Docker. Make sure you are in the root of the `leap` repo and then run
-
-```bash
-DOCKER_BUILDKIT=1 docker build -f tools/reproducible.Dockerfile -o . .
-```
-
-This command will take a substantial amount of time because a toolchain is built from scratch. Upon completion, the current directory will contain a built `.deb` and `.tar.gz` (you can change the `-o .` argument to place the output in a different directory). If needing to reduce the number of parallel jobs as warned above, run the command as,
-
-```bash
-DOCKER_BUILDKIT=1 docker build --build-arg LEAP_BUILD_JOBS=4 -f tools/reproducible.Dockerfile -o . .
-```
-
-##### Unpinned Build
-
-The following instructions are valid for this branch. Other release branches may have different requirements, so ensure you follow the directions in the branch or release you intend to build. If you are in an Ubuntu docker container, omit `sudo` because you run as `root` by default.
-
-Install dependencies:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y \
-        build-essential \
-        cmake \
-        git \
-        libcurl4-openssl-dev \
-        libgmp-dev \
-        llvm-11-dev \
-        python3-numpy \
-        file \
-        zlib1g-dev
-```
-
-On Ubuntu 20.04, install gcc-10 which has C++20 support:
-
-```bash
-sudo apt-get install -y g++-10
-```
-
-To build, make sure you are in the root of the `leap` repo, then run the following command:
-
-```bash
-mkdir -p build
-cd build
-
-## on Ubuntu 20, specify the gcc-10 compiler
-cmake -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
-
-## on Ubuntu 22, the default gcc version is 11, using the default compiler is fine
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/lib/llvm-11 ..
-
-make -j "$(nproc)" package
-```
-
-Now you can optionally [test](#step-4---test) your build, or [install](#step-5---install) the `*.deb` binary packages, which will be in the root of your build directory.
-
-#### Step 4 - Test
-
-Leap supports the following test suites:
-
-Test Suite | Test Type | [Test Size](https://testing.googleblog.com/2010/12/test-sizes.html) | Notes
----|:---:|:---:|---
-[Parallelizable tests](#parallelizable-tests) | Unit tests | Small
-[WASM spec tests](#wasm-spec-tests) | Unit tests | Small | Unit tests for our WASM runtime, each short but _very_ CPU-intensive
-[Serial tests](#serial-tests) | Component/Integration | Medium
-[Long-running tests](#long-running-tests) | Integration | Medium-to-Large | Tests which take an extraordinarily long amount of time to run
-
-When building from source, we recommended running at least the [parallelizable tests](#parallelizable-tests).
-
-##### Parallelizable Tests
-
-This test suite consists of any test that does not require shared resources, such as file descriptors, specific folders, or ports, and can therefore be run concurrently in different threads without side effects (hence, easily parallelized). These are mostly unit tests and [small tests](https://testing.googleblog.com/2010/12/test-sizes.html) which complete in a short amount of time.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-
-```bash
-ctest -j "$(nproc)" -LE _tests
-```
-##### WASM Spec Tests
-The WASM spec tests verify that our WASM execution engine is compliant with the web assembly standard. These are very [small](https://testing.googleblog.com/2010/12/test-sizes.html), very fast unit tests. However, there are over a thousand of them so the suite can take a little time to run. These tests are extremely CPU-intensive.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-```bash
-ctest -j "$(nproc)" -L wasm_spec_tests
-```
-We have observed severe performance issues when multiple virtual machines are running this test suite on the same physical host at the same time, for example in a CICD system. This can be resolved by disabling hyperthreading on the host.
-
-##### Serial Tests
-
-The serial test suite consists of [medium](https://testing.googleblog.com/2010/12/test-sizes.html) component or integration tests that use specific paths, ports, rely on process names, or similar, and cannot be run concurrently with other tests. Serial tests can be sensitive to other software running on the same host and they may `SIGKILL` other `nodeos` processes. These tests take a moderate amount of time to complete, but we recommend running them.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-```bash
-ctest -L "nonparallelizable_tests"
-```
-
-##### Long-Running Tests
-The long-running tests are [medium-to-large](https://testing.googleblog.com/2010/12/test-sizes.html) integration tests that rely on shared resources and take a very long time to run.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-```bash
-ctest -L "long_running_tests"
-```
-
-##### WASM Spec Tests
-
-The WASM spec tests verify that our WASM execution engine is compliant with the web assembly standard. These are very [small](https://testing.googleblog.com/2010/12/test-sizes.html), very fast unit tests. However, there are over a thousand of them so the suite can take a little time to run. These tests are extremely CPU-intensive.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-
-```bash
-ctest -j "$(nproc)" -L wasm_spec_tests
-```
-
-We have observed severe performance issues when multiple virtual machines are running this test suite on the same physical host at the same time, for example in a CICD system. This can be resolved by disabling hyperthreading on the host.
-
-##### Serial Tests
-
-The serial test suite consists of [medium](https://testing.googleblog.com/2010/12/test-sizes.html) component or integration tests that use specific paths, ports, rely on process names, or similar, and cannot be run concurrently with other tests. Serial tests can be sensitive to other software running on the same host and they may `SIGKILL` other `nodeos` processes. These tests take a moderate amount of time to complete, but we recommend running them.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-
-```bash
-ctest -L "nonparallelizable_tests"
-```
-
-##### Long-Running Tests
-
-The long-running tests are [medium-to-large](https://testing.googleblog.com/2010/12/test-sizes.html) integration tests that rely on shared resources and take a very long time to run.
-
-You can invoke them by running `ctest` from a terminal in your Leap build directory and specifying the following arguments:
-
-```bash
-ctest -L "long_running_tests"
-```
-
-#### Step 5 - Install
-
-Once you have [built](#step-3---build-the-source-code) Leap and [tested](#step-4---test) your build, you can install Leap on your system. Don't forget to omit `sudo` if you are running in a docker container.
-
-We recommend installing the binary package you just built. Navigate to your Leap build directory in a terminal and run this command:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y ./leap[-_][0-9]*.deb
-```
-
-It is also possible to install using `make` instead:
-
-```bash
-sudo make install
-```
-
-### Bash Autocomplete
-
-`cleos` and `leap-util` offer a substantial amount of functionality. Consider using bash's autocompletion support which makes it easier to discover all their various options.
-
-For our provided `.deb` packages simply install Ubuntu's `bash-completion` package: `apt-get install bash-completion` (you may need to log out/in after installing).
-
-If building from source install the `build/programs/cleos/bash-completion/completions/cleos` and `build/programs/leap-util/bash-completion/completions/leap-util` files to your bash-completion directory. Refer to [bash-completion's documentation](https://github.com/scop/bash-completion#faq) on the possible install locations.
+Production BPs should prefer the published package so every operator can verify the same artifact. If a source build is explicitly approved, use the exact tagged source and build instructions in the [TelosZero Core repository](https://github.com/telosnetwork/teloszero-core), record the commit, and publish a reproducible package checksum to the BP coordination channel before deployment.

--- a/docs/nodes/bp-nodes/node-system-requirements.mdx
+++ b/docs/nodes/bp-nodes/node-system-requirements.mdx
@@ -1,50 +1,131 @@
 ---
-title: "Node System Requirements"
+title: 'Block Producer System Requirements'
 displayed_sidebar: devBar
-description: >-
-    System requirements to run a 
-    node on Telos
-sidebar_position: 4
-hide_table_of_contents: true
+description: Infrastructure, security, storage, relay, and monitoring requirements for a Telos block producer and Savanna finalizer.
+sidebar_position: 5
+hide_table_of_contents: false
 ---
 
-# Node System Requirements
+# Block Producer System Requirements
 
-This document outlines the technical requirements for running various types of nodes on Telos, with a focus on optimizing performance and reliability within the Telos Blockchain Network.
+A post-Savanna BP is responsible for both scheduled block production and continuous finalizer voting. Size and secure the complete producer path, not only the `nodeos` process.
 
-## General Recommendations
+## Required topology
 
-### CPU Speeds for API Nodes
+A production BP should operate these separate roles:
 
-It is recommended not to exceed CPU speeds of 5 GHz for API nodes. Higher speeds may cause discrepancies in subjective billing, potentially leading to situations where transactions are initially accepted but ultimately rejected by nodes with slower CPUs.
+| Role | Purpose | Public exposure | Finalizer configuration |
+|---|---|---|---|
+| Primary producer | Produces blocks and signs finalizer votes | Private only | Unique BLS key, `vote-threads = 4`, persistent `finalizers-dir` |
+| Backup producer | Fully synced failover, with block production paused until handoff | Private only | Different pre-registered BLS key, its own safety state, and `pause-on-startup = true` |
+| Relay/sentry nodes | Isolate producers and carry P2P blocks, transactions, and votes | P2P as required | No BLS key; `vote-threads = 4` on every vote path |
+| Control/signing host | Holds BP account authority and submits on-chain actions | Restricted administration | No `nodeos` finalizer |
+| Public API/SHiP nodes | Serve applications, indexers, and public RPC | Public through a hardened proxy | No BLS key; no vote threads unless intentionally on a vote path |
 
-### Use of tmpfs File System
+Use at least two independent relay paths. Avoid a single firewall, provider, switch, transit link, or relay that can isolate the producer from peer finalizers.
 
-All nodes are advised to utilize the tmpfs file system for their node state folder. This approach requires the mounting of the node state folder onto a tmpfs partition, necessitating a large swap partition and at least 32GB of RAM. The tmpfs system operates entirely in virtual memory, ensuring fast access to data but also meaning that data is not persistently stored on disk and will be lost if the tmpfs instance is unmounted.
+## Producer hardware baseline
 
-### Storage for State History Nodes
+These are operational planning baselines, not consensus constants. Benchmark the approved TelosZero build and leave capacity for peak transaction load, replay, vote processing, monitoring, and failover.
 
-For nodes handling significant State History requests, it's recommended to use SSD or NVMe drives to accommodate the high throughput and storage access speed required.
+| Resource | Production baseline |
+|---|---|
+| CPU | Modern high-clock x86-64 CPU with at least 8 dedicated cores; reserve capacity for four vote threads and chain processing |
+| Memory | 64 GB ECC RAM recommended; never configure `chain-state-db-size-mb` above usable physical memory |
+| Storage | Enterprise NVMe SSD with power-loss protection; size for chain state, blocks, snapshots, logs, and growth |
+| Network | Redundant low-latency 1 Gbit/s or better connectivity with stable public and private routes |
+| Clock | Multiple reliable NTP sources with drift alerting |
+| Power | Redundant power where available and a tested graceful-shutdown path |
+| OS | Supported Ubuntu release for the approved TelosZero package; minimal services and current security updates |
 
-## Node Configuration Requirements
+Do not co-locate public API, SHiP, Hyperion, build, or analytics workloads on the private producer.
 
-### API Node without Blocks Log
+## Persistent finalizer storage
 
-CPU: 2 cores, each >= 3.7 GHz  
-RAM: 16 GB, with an additional 16 GB swap (32GB recommended)  
-Storage: 1024 GB HDD  
-Internet Connection: 100 Mb/s  
+`finalizers-dir` contains `safety.dat`, the voting history that prevents a BLS key from voting inconsistently.
 
-### API Node with Blocks Log
+Required properties:
 
-CPU: 4 cores, each >= 3.8 GHz  
-RAM: 32 GB  
-Storage: 1024 GB HDD  
-Internet Connection: 100 Mb/s or higher  
+- local persistent storage, not `tmpfs`;
+- owned by the `nodeos` service account and mode `0700`;
+- low-latency and monitored for write, checksum, permission, and capacity failures;
+- excluded from cross-host replication and generic backup-restore automation;
+- preserved in place through ordinary restarts, replays, and state snapshot recovery.
 
-### State History Node with Blocks Log
+Do not roll `safety.dat` back, copy it to a backup producer, or reuse its BLS key on a different host. If continuity is uncertain, use a never-used replacement key and follow the [finalizer recovery procedure](/nodes/bp-nodes/finalizer-setup/#recover-from-a-missing-or-corrupt-safetydat).
 
-CPU: 4 cores, each >= 3.8 GHz  
-RAM: 32 GB  
-Storage: 2048 GB HDD  
-Internet Connection: 100 Mb/s or higher  
+Node state may use a performance-oriented filesystem, but the finalizer directory must remain durable and independent of any process that recreates or clears `state/shared_memory.bin`.
+
+## Key custody
+
+Keep these key classes separate:
+
+- **BP owner/active authorities:** offline, multisig, or a hardened control/signing system; never on the producer.
+- **K1 block-signing key:** dedicated to producer block signing; not the account active key.
+- **BLS finalizer key:** unique to one `nodeos` host; never copied to primary/backup peers.
+
+Install any `config.ini` containing `PVT_K1` or `PVT_BLS` as `root:telos`
+with mode `0640`, so the service can read but cannot rewrite it. Put the writable
+`protocol-features-dir` under the instance data directory. Prefer an
+operator-approved remote signer/HSM for K1 signing when supported. In TelosZero
+1.2.x, the BLS provider is configured with `KEY`, so protect the host and file
+accordingly.
+
+Pre-generate and register a distinct backup BLS key before it is needed. The safest recovery model is key rotation, not restoration of an old finalizer key and partial voting history.
+
+## Network and relay requirements
+
+- Bind the producer HTTP API to `127.0.0.1`.
+- Permit producer P2P only from BP-controlled relays or an explicit allowlist.
+- Carry finalizer votes across every relay hop by setting `vote-threads = 4` on those relays.
+- Maintain independent inbound and outbound P2P paths.
+- Use current peer information from [validators.telos.net](https://validators.telos.net/) or its [machine-readable validation data](https://validators.telos.net/validation/latest.json), not a copied static peer list.
+- Test block, transaction, and vote propagation; a TCP handshake alone is insufficient.
+- Rate-limit and proxy public HTTP APIs on separate nodes. Never expose `producer_api_plugin` or `net_api_plugin` directly to the internet.
+
+## Monitoring and alerting
+
+Monitor the private producer, backup, relays, and public chain independently.
+
+Required signals include:
+
+- process uptime, restarts, version, and binary checksum;
+- head block, irreversible block, and sustained LIB lag;
+- active/pending finalizer policy and tracked vote freshness;
+- strong, weak, and missing-vote patterns;
+- scheduled rounds, missed blocks, and production handoffs;
+- P2P peer count, connection churn, latency, and both relay paths;
+- CPU saturation, memory pressure, filesystem latency, disk capacity, and inode use;
+- finalizer directory write/checksum/permission errors;
+- NTP offset and host clock jumps;
+- configuration and signing-key changes;
+- unexpected on-chain finalizer actions.
+
+Alerting must reach an operator who can execute the tested key-rotation and failover runbook at any time the BP is scheduled.
+
+## Backup and failover testing
+
+At least quarterly and before any major node release:
+
+1. Confirm the backup is on the approved artifact and synced.
+2. Confirm its BLS key is registered but inactive.
+3. Confirm `pause-on-startup = true` prevents the backup from publishing with the primary's K1 key.
+4. Exercise finalizer activation and the stop-primary/unpause-backup K1 handoff on testnet.
+5. Verify votes pass through both relay paths.
+6. Rehearse snapshot recovery with a new BLS key when safety history is unavailable.
+7. Verify owner/active authority recovery without copying those keys to producer hosts.
+
+Never run the same K1 block-signing key concurrently on two unpaused producers.
+BLS keys must remain unique per host, network, and `nodeos` instance even when
+K1 production is paused.
+
+## Public metadata requirements
+
+Maintain valid HTTPS-hosted `chains.json` and `bp.json` files with current:
+
+- organization and location details;
+- public API endpoints;
+- public P2P endpoints;
+- producer account and service information.
+
+Use the [Telos validator dashboard](https://validators.telos.net/) to validate published endpoints, SSL, active schedule, contract finalizer rows, and visible node versions. Private producer settings, BLS custody, relay propagation, and `safety.dat` continuity require separate operator evidence.

--- a/docs/nodes/bp-nodes/setting-up-telos-validator-nodes.mdx
+++ b/docs/nodes/bp-nodes/setting-up-telos-validator-nodes.mdx
@@ -1,473 +1,263 @@
 ---
-title: 'Setting up a Telos Block Producer Node'
+title: 'Set Up a Telos Block Producer'
 displayed_sidebar: devBar
-description: This section describes all the steps needed to set up a Telos Block Producer
+description: Configure, start, register, and verify a TelosZero block producer after Savanna activation.
 sidebar_position: 3
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
-# Setting up a Telos Block Producer Node
+# Set Up a Telos Block Producer
 
-## Run Nodeos
+This guide configures a new or replacement block producer on a Telos network where Savanna instant finality is already active.
 
-`nodeos` generally runs in 2 modes:
+A production BP has two separate signing responsibilities:
 
-### A. Producing/Active mode
+- a **K1 block-signing key** signs blocks produced during the BP's scheduled rounds;
+- a **BLS finalizer key** votes on blocks so the network can form quorum certificates and finalize them.
 
-`Producing Validator Nodes` are configured for block production. They connect to the peer-to-peer (p2p) network and actively produce new blocks. Loose transactions are also validated and relayed. On mainnet, Producing Validator Nodes only produce blocks if their assigned block producer is part of an active schedule.
+The finalizer is part of the producer's `nodeos` process. It is not a separate daemon.
 
-> NOTE: System contracts required - These instructions assume you want to launch a producing validator node on a network with system contracts loaded. These instructions will not work on a default development node using native functionality, or one without system contracts loaded.
+## Before you begin
 
-#### Goal
+Complete these prerequisites:
 
-This section describes how to set up a producing node within the Telos network. A producing node, as its name implies, is a node that is configured to produce blocks on the Telos blockchain. This functionality is provided through the producer\_plugin as well as other Nodeos Plugins.
+- [Review the producer system requirements](/nodes/bp-nodes/node-system-requirements/).
+- [Install TelosZero Core](/nodes/bp-nodes/installing-node-software/).
+- Obtain a registered Telos account for the BP.
+- Keep the account owner and active keys on a separate control/signing host. Do not store them on the producer.
+- Generate a dedicated K1 block-signing key. Never use the BP account's active key to sign blocks.
+- Prepare at least two private relay/sentry paths to the public Telos P2P network.
+- Publish the BP's `chains.json` and `bp.json` metadata over HTTPS.
 
-**nodeos plugins**
+:::warning Do not expose the producer
+The producer HTTP API should bind only to localhost. Its P2P listener should be reachable only by the BP's private relays or explicitly allowed peers. Run public API, SHiP, and history workloads on separate nodes.
+:::
 
-* Plugins extend the core functionality implemented in `nodeos`. Some plugins are mandatory, such as `chain_plugin`, `net_plugin`, and `producer_plugin`, which reflect the modular design of `nodeos`. The other plugins are optional as they provide nice-to-have features, but are non-essential for the node's operation.
-* The list of specific plugins is as follows:
-  * `blockvault_client_plugin`
-  * `chain_api_plugin`
-  * `chain_plugin`
-  * `db_size_api_plugin`
-  * `history_api_plugin`
-  * `history_plugin`
-  * `http_client_plugin`
-  * `http_plugin`
-  * `login_plugin`
-  * `net_api_plugin`
-  * `net_plugin`
-  * `producer_plugin`
-  * `state_history_plugin`
-  * `trace_api_plugin`
-  * `txn_test_gen_plugin`
+## 1. Prepare BP metadata
 
-> Nodeos is modular: Plugins add incremental functionality to `nodeos`. Unlike runtime plugins, nodeos plugins are built at compile-time.
+Host `chains.json` and `bp.json` under the base URL you will register on-chain. Include the BP organization, location, public API endpoints, public P2P endpoints, and producer information. Follow the [BP metadata standard](https://github.com/eosrio/bp-info-standard) and validate the published files as JSON.
 
-#### Pre-requisites
+The registered URL is the base website URL, not the full path to `bp.json`.
 
-* Install the [Leap software](/nodes/bp-nodes/installing-node-software) before starting this section.
-* It is assumed that `nodeos`, `cleos`, and `keosd` are accessible through the path. If you built Leap using shell scripts, make sure to run the Install Script.
-* Know how to pass Nodeos options to enable or disable functionality.
-
-#### Steps
-
-Please follow the steps below to set up a producing node:
-
-1. Local Wallet
-2. Create your `bp.json` for your Telos validator
-3. Register your account as a producing validator
-4. Set Producer Name
-5. Set the Producer's signature-provider
-6. Define a peer list
-7. Load the Required Plugins
-
-**1. Local Wallet**
-
-**a. Create Telos Wallet locally. Record the password and keep secure.**
-
-```
-cleos wallet create -n <wallet_name> --to-console
-<!-- OR -->
-cleos wallet create -n <wallet_name> --file <filename_with_extension>
+```text
+Registered URL: https://bp.example
+Metadata:       https://bp.example/bp.json
 ```
 
-**b. Unlock EOS Wallet. Paste your wallet password**
+The [Telos validator dashboard](https://validators.telos.net/) discovers public API and P2P endpoints from this metadata. It cannot inspect the private producer host.
 
-```
-cleos wallet unlock -n <wallet_name> --password <wallet_password>
-```
+## 2. Configure the private producer
 
-**c. Account creation:**
+Create `/etc/telos/mainnet-primary/config.ini` and replace every placeholder:
 
-* M-1: Use services like [Telos account creator](https://app.telos.net/accounts/add) to create your account.
-* M-2: Using CLI
+```ini
+# Private management API only
+http-server-address = 127.0.0.1:8888
+http-validate-host = false
 
-```
-cleos -u <api_endpoint> system newaccount --stake-net <telos_net_amount> --stake-cpu <telos_cpu_amount> --buy-ram-kbytes <telos_ram_amount> <telos_existing_account_name> <telos_existing_account_name> <owner-publickey> <active-publickey>
-```
+# Bind this to a private interface reachable by your relays
+p2p-listen-endpoint = <PRIVATE_PRODUCER_IP>:9876
+agent-name = "<BP_ACCOUNT>-producer"
 
-**d. Load new account private key into your wallet**
+# The TelosZero 1024 MiB default is too small for current Telos state.
+chain-state-db-size-mb = 32768
+protocol-features-dir = /var/lib/telos/mainnet-primary/protocol_features
 
-```
-cleos wallet import -n <wallet_name> <privkey>
-```
-
-**2. Create your bp.json for your Telos validator**
-
-This will be used by voting portals and websites to identify validators. The `bp.json` contains location info for your Block Validator, nodes, and also contains other identifiable information such as your Block Producer public key.
-
-For instance, [http://yourwebsite.com/bp.json](http://yourwebsite.com/bp.json) When you register your validator, the URL field should be filled with [http://yourwebsite.com](http://yourwebsite.com). Do not put the `bp.json` file in the URL.
-
-For instance, for Aloha, the `bp.json` is located at [https://www.alohaeos.com/bp.json](https://www.alohaeos.com/bp.json), the URL to locate this will be [https://www.alohaeos.com](https://www.alohaeos.com).
-
-* [Template for the standard bp\_info.json format for the EOS Mainnet.](https://github.com/eosrio/bp-info-standard)
-* You can find most Validator's bp.json on their websites.
-* Please conform to the [JSON format standard](https://www.w3schools.com/js/js\_json\_syntax.asp).
-* Here is an excellent [JSON validator](https://jsonformatter.org).
-
-**3. Register your account as a producing validator**
-
-In order for your account to be eligible as a producing validator, you will need to register the account as a producing validator:
-
-```
-<!-- cleos -u <api_endpoint> system regproducer <producer_account_name> <producer_signature_public_key> <producer_website> <producer-geo-location> -->
-cleos -u http://api.main.alohaeos.com system regproducer alohaeosprod EOS87wJkSDXLDVVoJUaBYd4tjg8F8chMWY5nPo8Mb5F919TpbjJvz https://www.alohaeos.com Honolulu
-```
-
-> NOTE: separate key pair used only for signing blocks and can not perform any other operation.
->
-> If you currently have your active key listed in your `config.ini` for signing blocks — you need to stop it and replace it with a separate Signature key
-
-Just follow this in order to replace the existing active (or insecure key) with a separate signature key
-
-* Create a new key pair using `cleos create key --to-console`
-* Replace the signature provider record in your `config.ini` with the new key: `signature-provider = EOS-SIGNATURE-PUBLIC-KEY=KEY:SIGNATURE-PRIVATE-KEY`
-* Call regproducer command with the new signature key: `cleos system regproducer [PRODUCER-NAME] [EOS-SIGNATURE-PUBLIC-KEY] {PRODUCER_URL] [COUNTRY_CODE]`
-
-**4. Set Producer Name**
-
-Set the `validator_name` option in `config.ini` to your account, as follows:
-
-```
-# config.ini:
-
-# ID of producer controlled by this node (e.g. inita; may specify multiple times) (eosio::producer_plugin)
-producer-name = alohaeosprod
-```
-
-**5. Set the Producer's signature-provider**
-
-You will need to set the separate private key for your validator. The public key should have an authority for the validator account defined above.
-
-`signature-provider` is defined with a 3-field tuple:
-
-* `public-key` - A valid EOSIO public key in form of a string.
-* `provider-spec` - It's a string formatted like :
-* `provider-type` - KEY or KEOSD
-
-**Using a Key:**
-
-```
-# config.ini:
-
-signature-provider = PUBLIC_SIGNING_KEY=KEY:PRIVATE_SIGNING_KEY
-
-//Example
-//signature-provider = EOS51PsUQXRKphEBPBP8iH8ZRGNvyqJ13hbR8yXGSPKEf5TQH27TF=KEY:5KgV1HsxEm3qKYdLaUgpdZvJcAV2AA7zVDJYBL7nVoE4mdcqQR1
-```
-
-**Using Keosd:**
-
-```
-# config.ini:
-
-signature-provider = KEOSD:<data>   
-
-//Example
-//EOS51PsUQXRKphEBPBP8iH8ZRGNvyqJ13hbR8yXGSPKEf5TQH27TF=KEOSD:https://127.0.0.1:88888
-```
-
-**6. Define a peers list**
-
-```
-# config.ini:
-
-# Default p2p port is 9876
-p2p-peer-address = 195.201.82.181:9876
-p2p-peer-address = 47.52.71.18:9876
-p2p-peer-address = 207.180.220.203:9876
-p2p-peer-address = 149.28.254.141:9876
-p2p-peer-address = p2p-telos.blckchnd.com:19876
-p2p-peer-address = p2p.blindblocart.io:9877
-p2p-peer-address = telos.caleos.io:9880
-p2p-peer-address = p2p.telos.cryptosuvi.io:2222
-```
-
-For more, visit here for [Telos Mainnet](https://github.com/telosnetwork/api-p2p-nodes/blob/master/TelosMainNet.csv) & [Telos Testnet](https://github.com/telosnetwork/api-p2p-nodes/blob/master/TelosTestnet.csv)
-
-**7. Load the Required Plugins**
-
-In your `config.ini`, confirm the following plugins are loading or append them if necessary.
-
-```
-# config.ini:
-
-plugin = eosio::chain_plugin
-plugin = eosio::producer_plugin
-```
-
-### B. Non-Producing or Standby mode
-
-`Non-Producing Validator Nodes` connect to the peer-to-peer (p2p) network but do not actively produce new blocks; they are useful for acting as proxy nodes, relaying API calls, validating transactions, broadcasting information to other nodes, etc. `Non-Producing Validator Nodes` are also useful for monitoring the blockchain state.
-
-#### Goal
-
-This section describes how to set up a non-producing validator node within the Telos network. A non-producing validator node is a node that is not configured to produce blocks, instead, it is connected and synchronized with other peers from the Telos blockchain, exposing one or more services publicly or privately by enabling one or more Nodeos Plugins, except the producer\_plugin.
-
-#### Pre-requisites
-
-* Install the [EOSIO software](https://github.com/EOSIO/eos) before starting this section.
-* It is assumed that `nodeos`, `cleos`, and `keosd` are accessible through the path. If you built Leap using shell scripts, make sure to run the Install Script.
-* Know how to pass Nodeos options to enable or disable functionality.
-
-#### Steps
-
-Please follow the steps below to set up a non-producing node:
-
-1. Set Peers
-2. Enable one or more available plugins
-
-**1. Set Peers**
-
-You need to set some peers in your config ini, for example:
-
-```
-# config.ini:
-
-# Default p2p port is 9876
-p2p-peer-address = 195.201.82.181:9876
-p2p-peer-address = 47.52.71.18:9876
-p2p-peer-address = 207.180.220.203:9876
-p2p-peer-address = 149.28.254.141:9876
-p2p-peer-address = p2p-telos.blckchnd.com:19876
-p2p-peer-address = p2p.blindblocart.io:9877
-p2p-peer-address = telos.caleos.io:9880
-p2p-peer-address = p2p.telos.cryptosuvi.io:2222
-```
-
-For more, visit here for [Telos Mainnet](https://github.com/telosnetwork/api-p2p-nodes/blob/master/TelosMainNet.csv) & [Telos Testnet](https://github.com/telosnetwork/api-p2p-nodes/blob/master/TelosTestnet.csv)
-
-Or you can include the peer in as a boot flag when running `nodeos`, as follows:
-
-```
-nodeos ... --p2p-peer-address=106.10.42.238:9876
-```
-
-**2. Enable one or more available plugins**
-
-Each available plugin is listed and detailed in the Nodeos Plugins section. When `nodeos` starts, it will expose the functionality provided by the enabled plugins it was started with. For example, if you start `nodeos` with `state_history_plugin` enabled, you will have a non-producing node that offers full blockchain history. If you start `nodeos` with `http_plugin` enabled, you will have a non-producing node which exposes the Telos RPC API. Therefore, you can extend the basic functionality provided by a non-producing node by enabling any number of existing plugins on top of it. Another aspect to consider is that some plugins have dependencies to other plugins. Therefore, you need to satisfy all dependencies for a plugin in order to enable it.
-
-## Configuration Files
-
-### Mainnet
-
-#### genesis.json
-
-```javascript
-{
- "initial_key": "EOS52vfcN43YHHU8Akh7VyfBdnDiMg15dPTELosWG9SR86ssBoU1T",
- "initial_configuration": {
-   "max_transaction_delay": 3888000,
-   "min_transaction_cpu_usage": 100,
-   "net_usage_leeway": 500,
-   "context_free_discount_net_usage_den": 100,
-   "max_transaction_net_usage": 524288,
-   "context_free_discount_net_usage_num": 20,
-   "max_transaction_lifetime": 3600,
-   "deferred_trx_expiration_window": 600,
-   "max_authority_depth": 6,
-   "max_transaction_cpu_usage": 5000000,
-   "max_block_net_usage": 1048576,
-   "target_block_net_usage_pct": 1000,
-   "max_generated_transaction_count": 16,
-   "max_inline_action_size": 4096,
-   "target_block_cpu_usage_pct": 1000,
-   "base_per_transaction_net_usage": 12,
-   "max_block_cpu_usage": 50000000,
-   "max_inline_action_depth": 4
- },
- "initial_timestamp": "2018-12-12T10:29:00.000"
-}
-```
-
-#### config.ini
-
-```
-###### producer plugin options - enable if running producer node
-plugin = eosio::producer_plugin
-## sig provider keys should match the key on your producer-name
-signature-provider = <pubkey>=KEY:<privkey>
-producer-name = <your unique telos account name>
-
-## additional producer plugin options can be left default
-max-transaction-time = 10000
-max-irreversible-block-age = -1
-abi-serializer-max-time-ms = 2000
-enable-stale-production = true
-pause-on-startup = false
-
-###### chain plugin options
-plugin = eosio::chain_plugin
-wasm-runtime = wabt
-reversible-blocks-db-size-mb = 340
-contracts-console = false
-## set chain-state-db-size-mb to equal the size of your RAM
-chain-state-db-size-mb = 98304
-
-###### http plugin options
+# Minimal producer plugins
 plugin = eosio::http_plugin
-http-server-address = 0.0.0.0:1880
-access-control-allow-origin = *
-access-control-allow-credentials = false
-https-client-validate-peers = 1 
-verbose-http-errors = true
-http-validate-host = 0
-## enable if using https
-# https-server-address = 0.0.0.0:443
-# https-certificate-chain-file
-
-# nodeos general config
-p2p-server-address = 0.0.0.0:9876
-p2p-listen-endpoint = 0.0.0.0:9876
-p2p-max-nodes-per-host = 1
-max-clients = 250
-connection-cleanup-period = 30
-sync-fetch-span = 100
-txn-reference-block-lag = 0
-allowed-connection = any
-agent-name = bensigcoolconfig
-
-###### additional plugins
-plugin = eosio::chain_api_plugin
-plugin = eosio::history_plugin
-
-###### p2p peer address
-p2p-peer-address = 159.69.63.222:7776
-p2p-peer-address = 109.237.25.217:3876
-p2p-peer-address = testnet.telos.caleos.io:9879
-p2p-peer-address = p2p.testnet.telos.eosdetroit.io:1337
-p2p-peer-address = telosafrique.eosnairobi.io:9376
-p2p-peer-address = telos.eosbcn.com:9876
-p2p-peer-address = testnet.telos.eosindex.io:9876
-```
-
-### Testnet
-
-#### genesis.json
-
-```javascript
-{
-"initial_key": "EOS7xyPWfh6743fhZ46zQQcXSctddoqG65d44YsyRnCJCs54mJLrH",
-"initial_configuration": {
-   "max_block_net_usage": 1048576,
-   "target_block_net_usage_pct": 1000,
-   "max_transaction_net_usage": 524288,
-   "base_per_transaction_net_usage": 12,
-   "net_usage_leeway": 500,
-   "context_free_discount_net_usage_num": 20,
-   "context_free_discount_net_usage_den": 100,
-   "max_block_cpu_usage": 5000000,
-   "target_block_cpu_usage_pct": 1000,
-   "max_transaction_cpu_usage": 150000,
-   "min_transaction_cpu_usage": 100,
-   "max_transaction_lifetime": 3600,
-   "deferred_trx_expiration_window": 600,
-   "max_transaction_delay": 3888000,
-   "max_inline_action_size": 4096,
-   "max_inline_action_depth": 4,
-   "max_authority_depth": 6
- },
-"initial_timestamp": "2019–08–07T12:00:00.000"
-}
-```
-
-#### config.ini
-
-```
-###### producer plugin options - enable if running producer node
-plugin = eosio::producer_plugin
-## sig provider keys should match the key on your producer-name
-signature-provider = <pubkey>=KEY:<privkey>
-producer-name = <your unique telos account name>
-
-## additional producer plugin options can be left default
-max-transaction-time = 10000
-max-irreversible-block-age = -1
-abi-serializer-max-time-ms = 2000
-enable-stale-production = true
-pause-on-startup = false
-
-###### chain plugin options
 plugin = eosio::chain_plugin
-wasm-runtime = wabt
-reversible-blocks-db-size-mb = 340
-contracts-console = false
-## set chain-state-db-size-mb to equal the size of your RAM
-chain-state-db-size-mb = 98304
-
-###### http plugin options
-plugin = eosio::http_plugin
-http-server-address = 0.0.0.0:1880
-access-control-allow-origin = *
-access-control-allow-credentials = false
-https-client-validate-peers = 1 
-verbose-http-errors = true
-http-validate-host = 0
-## enable if using https
-# https-server-address = 0.0.0.0:443
-# https-certificate-chain-file
-
-# nodeos general config
-p2p-server-address = 0.0.0.0:9876
-p2p-listen-endpoint = 0.0.0.0:9876
-p2p-max-nodes-per-host = 1
-max-clients = 250
-connection-cleanup-period = 30
-sync-fetch-span = 100
-txn-reference-block-lag = 0
-allowed-connection = any
-agent-name = bensigcoolconfig
-
-###### additional plugins
 plugin = eosio::chain_api_plugin
-plugin = eosio::history_plugin
+plugin = eosio::net_plugin
+plugin = eosio::producer_plugin
 
-###### p2p peer address
-p2p-peer-address=testnet2.telos.eosusa.news:59877
-p2p-peer-address=node1.testnet2.telosglobal.io:9876
-p2p-peer-address=node2.testnet2.telosglobal.io:9876
-p2p-peer-address=basho.eos.barcelona:9899
-p2p-peer-address=sslapi.teloscentral.com:9875
-p2p-peer-address=145.239.133.188:5566
-p2p-peer-address=testnet.telos.eclipse24.io:6789
-p2p-peer-address=testnet2.telos.eosdetroit.io:1337
-p2p-peer-address=basho-p2p.telosuk.io:19876
-p2p-peer-address=telos-testnet.atticlab.net:7876
-p2p-peer-address=testnet.eossweden.eu:8022
-p2p-peer-address=testnet.telos.cryptosuvi.io:2223
-p2p-peer-address=nickfury.tlos.goodblock.io:9876
-p2p-peer-address=telosapi.eosmetal.io:59877
-p2p-peer-address=207.148.6.75:9877
-p2p-peer-address=p2p.testnet.telosgermany.io
-p2p-peer-address=176.9.86.214:9877
-p2p-peer-address=telos-testnet-b.eosphere.io:9876
-p2p-peer-address=testnet.telos.africa:9875
-p2p-peer-address=p2p.testnet.telosgreen.com:9876
-p2p-peer-address=testnet2p2p.telosarabia.net:9876
-p2p-peer-address=peer.tlostest.alohaeos.com:9876
-p2p-peer-address=157.230.29.117:9876
+# Producer identity and the dedicated K1 block-signing key
+producer-name = <BP_ACCOUNT>
+signature-provider = <PUB_K1_BLOCK_KEY>=KEY:<PVT_K1_BLOCK_KEY>
+
+# Savanna finalizer; generate these values in the next guide
+signature-provider = <PUB_BLS_FINALIZER_KEY>=KEY:<PVT_BLS_FINALIZER_KEY>
+vote-threads = 4
+finalizers-dir = /var/lib/telos/finalizers/mainnet-primary
+production-pause-vote-timeout-ms = 6000
+
+# Connect only to BP-controlled relay/sentry nodes
+p2p-peer-address = <PRIVATE_RELAY_A>:9876
+p2p-peer-address = <PRIVATE_RELAY_B>:9876
 ```
 
-## Frequently Asked Questions (FAQs)
+`chain-id` is not a valid `nodeos` configuration option. The chain is selected
+by the node's genesis or snapshot state. Verify the resulting `chain_id` through
+`get_info` after startup as shown below.
 
-#### Q. How does a Validator create a new account on Telos Blockchain?
+The 32768 MiB chain-state capacity is a reviewed starting point for a host with
+the recommended 64 GB RAM. Keep it below usable physical memory and raise it
+deliberately as measured chain state grows.
 
-#### A. There are 2 ways to create an account on Telos Blockchain:
+Protect the file because it contains signing material:
 
-a. [Telos account creator](https://app.telos.net/accounts/add) b. [Using CLEOS](/zero/developer-environment/cleos)
+```bash
+sudo chown root:telos /etc/telos/mainnet-primary/config.ini
+sudo chmod 0640 /etc/telos/mainnet-primary/config.ini
+```
 
-#### Q. What is the difference between Telos Mainnet and Testnet?
+The explicit `protocol-features-dir` keeps nodeos's writable generated protocol
+feature files under the instance data directory, so the key-bearing
+configuration can remain root-owned and read-only to the service account.
 
-#### A. The differences are as follows:
+Do not copy any of these legacy settings from the old BP guide:
 
-a. The mainnet of a blockchain launches when the protocol is fully developed and is the network where the project's functionalities, such as transactions with the native tokens, are carried out. Here is where transactions are being broadcasted, verified, and recorded on a distributed ledger technology. Whereas the testnet is a safe, separate network where developers carry out tests in the code without risking the main blockchain. The Telos Testnets are a sandbox for testing newly implemented features, finding bugs within the network and developing DApps. a. Testnet is for testing code updates, other functionalities, bug identification, new projects and program development, among many other uses. b. People associate a testnet with the initial developing of a blockchain where all the codes run, and we test everything before the final deployment of the protocol to the mainnet. c. the Telos testnets have one prominent advantage over the other testnets: it is a duplicate of the mainnet so it includes all its smart contracts and functionalities in the testnets. Because of this, developers and BPs obtain complete, accurate results when they run their tests, while reducing the work they have to do before running them. e. Testnet is designed to be as close to the code/features of the Telos Mainnet, with exception to any new innovations being tested in preparation for deployment on Mainnet.
+```ini
+# Invalid, removed, or unsafe for a current production BP:
+# wasm-runtime = wabt
+# plugin = eosio::history_plugin
+# producer-threads = ...
+# enable-stale-production = true
+```
 
-#### Q. When a new upgrade or anything different will be tested before launch, what test strategies the Telos Validators follow?
+`vote-threads = 4` is the producer default in TelosZero Core, but keep it explicit so the intended finalizer role is auditable. A relay that must forward votes also needs an explicit non-zero value; see [Configure vote relays](/nodes/bp-nodes/finalizer-setup/#configure-vote-relays).
 
-#### A. Telos Validators follow a 4-tier test strategy, as it allows “to properly test/vet things at each respective level, and as it progresses through the tiers, additional testing/testers stress-test the system until its final deployment to the Telos Mainnet.” The stages are:
+Keep `production-pause-vote-timeout-ms = 6000`. Setting it to `0` disables the
+guard that pauses block production when recent finalizer votes disappear.
 
-* Internal Dev Testing: closed-loop testing of all code changes before presenting to any public tier.
-* Stagenet Testing: initial selected access, testing ran dedicated nodes.
-* Testnet Testing: this is where most public testing of features will occur before completing deployment to Mainnet. Code changes/activation at this level require 15/21 approval of the Testnet BPs.
-* Mainnet Deployment: once all testing has been completed, a deployment date agreed upon, a 15/21 BP approval is needed to activate all code changes/features on the Mainnet.
+## 3. Add logging
+
+Create `/etc/telos/mainnet-primary/logging.json` using your normal centralized logging policy. At minimum, retain `nodeos`, P2P, producer, and vote/finality logs long enough to investigate missed blocks, missed votes, forks, and failovers.
+
+If `logging.json` is stored in the config directory, `nodeos` loads it automatically.
+
+## 4. Create a systemd service
+
+Create `/etc/systemd/system/telos-nodeos@.service`:
+
+```ini
+[Unit]
+Description=TelosZero Core node (%i)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=telos
+Group=telos
+UMask=0077
+WorkingDirectory=/var/lib/telos/%i
+ExecStart=/usr/bin/nodeos --config-dir=/etc/telos/%i --data-dir=/var/lib/telos/%i
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=300
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Load the service definition, but do not start it until the finalizer key is present in `config.ini`:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable telos-nodeos@mainnet-primary
+```
+
+## 5. Generate and configure the finalizer
+
+Complete the first two sections of [Initial finalizer setup](/nodes/bp-nodes/finalizer-setup/#initial-finalizer-setup) now:
+
+1. generate a unique BLS key and proof of possession for this instance;
+2. place its `signature-provider` entry in `config.ini`;
+3. confirm the persistent `finalizers-dir` permissions.
+
+Then return here to start and sync the node. Register the BP account before submitting `regfinkey`.
+
+The first `regfinkey` for a producer becomes that producer's active finalizer key automatically. Do not run `actfinkey` for an initial key. `actfinkey` is for switching to a second, already registered key.
+
+## 6. Start and sync the node
+
+:::warning Replacing an already scheduled producer
+Start the replacement with `pause-on-startup = true`. This pauses K1 block
+production while still allowing finalizer voting. Prove the old K1 signer is
+stopped and fenced, and use a new BLS key with its own safety history, before
+removing the pause and restarting. Never enable the same K1 key on two hosts at
+once, and never share or reuse a BLS key between hosts.
+:::
+
+For a new data directory, perform the one-time snapshot start from the [installation guide](/nodes/bp-nodes/installing-node-software/#5-first-start-from-the-snapshot). For subsequent starts:
+
+```bash
+sudo systemctl start telos-nodeos@mainnet-primary
+sudo systemctl status telos-nodeos@mainnet-primary
+sudo journalctl -u telos-nodeos@mainnet-primary -f
+```
+
+Confirm the local node is on mainnet and at head:
+
+```bash
+curl -s http://127.0.0.1:8888/v1/chain/get_info \
+  | jq '{chain_id, server_full_version_string, head_block_num, last_irreversible_block_num, head_block_time, head_block_producer}'
+```
+
+Required checks:
+
+- `chain_id` exactly matches the Telos mainnet chain ID;
+- `head_block_num` advances continuously;
+- `head_block_time` is current;
+- the node remains close to the network head and irreversible block;
+- logs show no key parsing, finalizer safety, fork, or persistent P2P errors.
+
+Do not register the first finalizer key until this process is running with the BLS key loaded.
+
+## 7. Register the producer
+
+Run governance transactions from the separate control/signing host. Set the public values:
+
+```bash
+export RPC=https://mainnet.telos.net
+export BP_ACCOUNT=<BP_ACCOUNT>
+export BLOCK_SIGNING_PUBLIC_KEY=<PUB_K1_BLOCK_KEY>
+export BP_URL=https://bp.example
+export BP_LOCATION=<UINT16_LOCATION>
+```
+
+Register or update the producer:
+
+```bash
+cleos -u "$RPC" system regproducer \
+  "$BP_ACCOUNT" \
+  "$BLOCK_SIGNING_PUBLIC_KEY" \
+  "$BP_URL" \
+  "$BP_LOCATION" \
+  -p "$BP_ACCOUNT@active"
+```
+
+`BP_LOCATION` is a numeric `uint16` value. A city name is invalid. Use the value chosen for the BP's published location policy; use `0` only when no location value is being declared.
+
+Confirm the producer row:
+
+```bash
+cleos -u "$RPC" system listproducers -l 200 \
+  | grep "$BP_ACCOUNT"
+```
+
+## 8. Register and verify the finalizer
+
+Return to [Register the first finalizer key](/nodes/bp-nodes/finalizer-setup/#5-register-the-first-finalizer-key). The first registration automatically selects that key in the contract table. Complete the table, native-policy, vote, relay, and backup checks before the BP enters the active schedule.
+
+## 9. Production readiness checklist
+
+Before accepting an active schedule slot, confirm all of the following:
+
+- [ ] The producer runs the approved TelosZero Core artifact and checksum.
+- [ ] Mainnet chain ID, head, and irreversible block are correct and advancing.
+- [ ] Account owner/active keys are absent from the producer host.
+- [ ] The K1 block-signing key is dedicated to block production.
+- [ ] The BLS key is unique to this `nodeos` instance and active on-chain.
+- [ ] `vote-threads = 4` is set on the producer and every required relay hop.
+- [ ] `production-pause-vote-timeout-ms = 6000` remains enabled.
+- [ ] `finalizers-dir` is persistent, local, mode `0700`, and not on `tmpfs`.
+- [ ] No `safety.dat` or BLS key was copied from another host.
+- [ ] At least two independent relay paths carry blocks, transactions, and votes.
+- [ ] Producer HTTP and P2P ports are not exposed to the public internet.
+- [ ] The backup producer has its own pre-generated and pre-registered BLS key and starts with K1 production paused.
+- [ ] Block production, missed votes, finality, peer count, clock, disk, and process health are monitored.
+- [ ] Published `chains.json`/`bp.json`, API, SSL, and public P2P endpoints pass [validators.telos.net](https://validators.telos.net/).
+
+The public validator checker cannot prove private key custody, producer configuration, relay vote propagation, or the integrity of `safety.dat`; those remain operator responsibilities.

--- a/docs/nodes/bp-nodes/what-is-a-telos-block-producer-node.mdx
+++ b/docs/nodes/bp-nodes/what-is-a-telos-block-producer-node.mdx
@@ -1,37 +1,50 @@
 ---
-title: 'What is a Telos Block Producer Node'
+title: 'What Is a Telos Block Producer?'
 displayed_sidebar: devBar
-description: >-
-  This section will cover the details regarding what a Telos Block Producer is
-  and its role in the Telos network.
+description: The block-production, finalizer, infrastructure, and governance responsibilities of a Telos BP.
 sidebar_position: 1
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
-# What is a Telos Block Producer Node
+# What Is a Telos Block Producer?
 
-In the Telos network, special nodes called "Telos validator nodes" perform block production and validation validation. Validator nodes are elected by Telos stakeholders via DPoS Consensus Algorithm. Each validator node runs an instance of a Telos node using the `nodeos` service. For this reason, validators that are on the active schedule to produce blocks are also called "active" or "producing" validator nodes.
+Telos block producers (BPs) are stakeholder-elected operators that run the Telos Zero network. Each registered BP may enter the active producer schedule according to Telos governance and voting rules.
 
-Follow this link to a full list of [Telos on-chain Governance documents](https://app.telos.net/governance). To view our minimum requirements for becoming a block producer, see our [Node System Requirements](/nodes/bp-nodes/node-system-requirements).
+On the post-Lightspeed network, an active BP performs two consensus roles in TelosZero Core:
 
-Before getting started as a block producer, you need to know a few things:
+- **Block producer:** publishes blocks during its scheduled production rounds and signs them with a dedicated K1 block-signing key.
+- **Savanna finalizer:** continuously votes on valid blocks with a BLS key so a supermajority can form quorum certificates and make blocks irreversible.
 
-1. A block producer needs to know its role & fulfill the requirements.
-2. Having more block producers is healthier and better for the Telos ecosystem, especially block producers who are committed to transparency and being in a state of giving continuous contributions.
-3. Block producers are a core component of the Telos network built on the Antelope protocol.
-4. Below is the guide to getting a node up and running as a block producer on Telos.
+The finalizer runs inside the BP's `nodeos` process; it is not a separate application. A producer without a correctly configured, registered, and active finalizer key is not ready for an active schedule slot.
 
-## What is the role of a Telos block producer
+## Operator responsibilities
 
-* Block producer nodes are decentralized entities that govern the Telos blockchain. block producer will produce the blocks of the Telos blockchain.
-* Telos block producers play a key role in the operation of the network.
-  * They provide stability, reliability, security, and extensive infrastructure coverage for the Telos network.
-  * Contribute to Telos development toolkits, so as to get noticed by the voters & stay in the BP list eligible for incentives (in TLOS tokens).
-* Telos block producers verify transactions on the Telos network by collecting transaction data and storing that information in blocks.&#x20;
-  * Once a block is prepared, validators broadcast the block to the network for verification.
-  * Block producers will earn block rewards in the form of TLOS tokens produced by token inflation.
-* Block producers are responsible for Telos infrastructure growth, community support and education, and financial support for the development of Telos DApps.
-* Block producers need to participate in on-chain governance. For more, refer to [this](https://app.telos.net/governance).
-* Block producers can have a look at the [Telos Node System Requirements](/nodes/bp-nodes/node-system-requirements).
+A BP is responsible for more than keeping one process online. Production operation includes:
 
-The next section will discuss the different types of nodes on the Telos network.
+- running an operator-approved [TelosZero Core](https://github.com/telosnetwork/teloszero-core) release;
+- maintaining private primary and backup producers with distinct finalizer keys and backup block production paused until an exclusive K1 handoff;
+- carrying blocks, transactions, and finalizer votes through redundant relay/sentry paths;
+- protecting account, block-signing, and finalizer keys according to their different roles;
+- preserving the continuous local voting history in `finalizers/safety.dat`;
+- publishing accurate `chains.json` and `bp.json` endpoint metadata;
+- monitoring block production, votes, finality, peers, storage, clocks, and failover readiness;
+- participating in Telos governance and coordinated network operations.
+
+## Keys used by a BP
+
+| Key | Purpose | Where it belongs |
+|---|---|---|
+| Account owner/active authority | Governance and on-chain account actions | Offline/multisig or a hardened control host, never the producer |
+| K1 block-signing key | Signs blocks during scheduled rounds | Producer signing configuration or approved signer |
+| BLS finalizer key | Signs Savanna finalizer votes | One unique key per producer-capable `nodeos` host |
+
+Never use the BP account's active key as the block-signing key. Never reuse a BLS finalizer key across primary and backup hosts.
+
+## Start here
+
+1. [Review the BP system requirements](/nodes/bp-nodes/node-system-requirements/).
+2. [Install TelosZero Core](/nodes/bp-nodes/installing-node-software/).
+3. [Configure and register the block producer](/nodes/bp-nodes/setting-up-telos-validator-nodes/).
+4. [Set up, verify, and protect the finalizer](/nodes/bp-nodes/finalizer-setup/).
+
+The [Telos validator dashboard](https://validators.telos.net/) reports public chain, endpoint, version, schedule, and finalizer-table signals. It cannot prove private producer configuration, key custody, relay propagation, or `safety.dat` integrity; BPs must verify those controls themselves.

--- a/docs/nodes/nodeos.mdx
+++ b/docs/nodes/nodeos.mdx
@@ -1,24 +1,50 @@
 ---
 sidebar_position: 3
 displayed_sidebar: devBar
-title: "Nodeos"
-hide_table_of_contents: true
+title: 'Nodeos'
+hide_table_of_contents: false
 ---
 
 # Nodeos
 
-`Nodeos` is distributed as part of the Antelope.io software suite. Each node can be configured (with specific functional plugins) to function as a:
-1. Block Producing node; or as 
-2. Non-producing node.
+`nodeos` is the Telos Zero node daemon. On Telos it is distributed in [TelosZero Core](https://github.com/telosnetwork/teloszero-core), the Telos-maintained continuation of Antelope Spring with Savanna consensus support.
 
-The behaviour of nodeos is determined mainly by which plug-ins are loaded and which plug-in options are used. Some plug-ins are mandatory (`chain_plugin`, `net_plugin`, and `producer_plugin`) while others are optional. For a full list of plug-ins, please visit [Nodeos Plug-ins](https://developers.eos.io/manuals/eos/latest/nodeos/plugins/index) for more details.
+TelosZero Core keeps the established runtime command names:
 
-`cleos` (CLI + EOS) is a command line interface with REST APIs exposed by `nodeos`. `cleos`. It is required to interact with the blockchain (via `nodeos`) and manages wallets (via `keosd`). Developers can also use cleos to deploy and test Telos smart contracts.
+- `nodeos` processes blocks and transactions, participates in P2P, serves APIs, produces blocks, and signs finalizer votes according to configuration;
+- `cleos` queries chain APIs and creates/signs transactions;
+- `keosd` manages supported wallet keys for `cleos`;
+- `spring-util` provides block-log, snapshot, chain-state, and BLS finalizer-key utilities.
 
-`keosd` (Key + EOS)  is a key manager service daemon for storing private keys and signing digital messages. It provides a secure key storage medium for keys to be encrypted at rest in the associated wallet file. `keosd` also defines a secure enclave for signing transaction created by cleos or a third part library.
+## Plugins and roles
 
-# Nodeos Getting Started
+`nodeos` functionality is selected through plugins and configuration options. Common plugins include:
 
-To install `nodeos` visit [Antelope.io Software Installation section](https://developers.eos.io/manuals/eos/latest/install/index), and follow the instructions provided. If you are new to Antelope, it is recommended that you install the [Antelope Prebuilt Binaries](https://github.com/AntelopeIO/leap), then proceed to the Getting Started section of the Antelope Developer Portal. 
+- `eosio::chain_plugin`
+- `eosio::net_plugin`
+- `eosio::producer_plugin`
+- `eosio::http_plugin`
+- `eosio::chain_api_plugin`
+- `eosio::state_history_plugin`
 
-If you are an advanced developer, a block producer, or no binaries are available for your platform, you may need to Build Antelope from source instead.
+The legacy `history_plugin` is not part of the supported post-Savanna setup. Use State History for indexers and keep public API/SHiP workloads off private producers.
+
+## Finalizer support
+
+When a producer configures a `PUB_BLS_...` signature provider, `vote-threads`, and `finalizers-dir`, the same `nodeos` process can sign Savanna finalizer votes. Relays on the vote path need vote threads but no BLS key. Pure API/SHiP nodes do not need to process votes.
+
+See [Finalizer Setup and Operations](/nodes/bp-nodes/finalizer-setup/) for the full lifecycle and safety rules.
+
+## Install and verify
+
+- BPs: [Install TelosZero Core](/nodes/bp-nodes/installing-node-software/)
+- Non-producing/exchange nodes: [TelosZero upgrade guide](/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide/)
+- Releases: [github.com/telosnetwork/teloszero-core/releases](https://github.com/telosnetwork/teloszero-core/releases/latest)
+
+```bash
+nodeos --full-version
+cleos version client
+spring-util version full
+```
+
+Use only the tagged artifact and checksum approved for the target network.

--- a/docs/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide.mdx
+++ b/docs/nodes/non-bp-nodes/exchange-teloszero-upgrade-guide.mdx
@@ -36,7 +36,7 @@ TelosZero Core is the Telos-maintained continuation of **Antelope Spring** (whic
 
 ### Exchanges do **not** need finalizer (BLS) keys
 
-Spring/Savanna finalizer keys and the `signature-provider` / `regfinkey` / `actfinkey` workflow apply **only to block producers**. As an exchange running non-producing API nodes, you can ignore all finalizer-key steps. `vote-threads` can be left at its **default of `4`** on API nodes — you do not need to change it.
+Savanna finalizer keys and the BLS `signature-provider` / `regfinkey` / `actfinkey` workflow apply **only to block producers**. As an exchange running non-producing API nodes, you can ignore all finalizer-key steps. Pure API and SHiP nodes outside a BP vote path can leave vote processing disabled (the non-producer default). Only an intentional intermediate vote relay should set `vote-threads = 4`; that relay still does not need a BLS key.
 
 ---
 
@@ -298,7 +298,6 @@ plugin = eosio::http_plugin
 
 # Bind the HTTP API locally; put nginx/haproxy in front for TLS
 http-server-address = 127.0.0.1:8888
-access-control-allow-origin = *
 http-validate-host = false
 http-max-response-time-ms = 100      # default lowered to 15ms in Leap 5+, raise for heavy calls
 
@@ -315,7 +314,12 @@ read-only-read-window-time-us = 165000
 
 # State/DB sizing — size generously for an exchange node
 chain-state-db-size-mb = 32768
+protocol-features-dir = /var/lib/telos/mainnet-api/protocol_features
 ```
+
+Do not enable wildcard CORS on a public RPC. If a browser application requires
+CORS, configure its exact trusted origin at the reverse proxy and keep `nodeos`
+bound to localhost.
 
 :::note
 `producer_api_plugin` is only needed to *take snapshots*. If it was not part of your normal configuration, disable it again after you have your snapshot.
@@ -323,13 +327,11 @@ chain-state-db-size-mb = 32768
 
 ### Network reference
 
-```ini
-# --- Telos Mainnet ---
-chain-id = 4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11
-
-# --- Telos Testnet ---
-# chain-id = 1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f
-```
+`chain-id` is not a valid `nodeos` configuration option. The genesis or snapshot
+selects the chain; verify `chain_id` after startup. Expected values are mainnet
+`4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11`
+and testnet
+`1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f`.
 
 Genesis files for both networks are included in the [node-template](https://github.com/telosnetwork/node-template) repo (and in the TelosZero Core `genesis/` directory).
 
@@ -338,35 +340,36 @@ Genesis files for both networks are included in the [node-template](https://gith
 An API node needs very little. This lean **mainnet** config is enough to run and serve the chain API — set `agent-name`, append your [P2P peers](#appendix-current-mainnet-p2p-peers), and start:
 
 ```ini
-# API HTTP port (put nginx/haproxy + SSL in front)
-http-server-address = 0.0.0.0:8888
+# API HTTP port (put nginx/haproxy + TLS in front)
+http-server-address = 127.0.0.1:8888
+http-validate-host = false
 # P2P port (TCP only, no proxy/SSL)
 p2p-listen-endpoint = 0.0.0.0:9876
 agent-name = "your-exchange-telos-api"
-
-chain-id = 4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11
-chain-state-db-size-mb = 65536        # size to your RAM
-access-control-allow-origin = *
-http-validate-host = false
+chain-state-db-size-mb = 32768
+protocol-features-dir = /var/lib/telos/mainnet-api/protocol_features
 
 plugin = eosio::http_plugin
 plugin = eosio::chain_plugin
 plugin = eosio::chain_api_plugin
 plugin = eosio::net_plugin
-plugin = eosio::producer_plugin
+
+vote-threads = 0
+api-accept-transactions = false
 
 # Append your peers here (see appendix), e.g.:
 # p2p-peer-address = telos.caleos.io:9877
 # p2p-peer-address = telos.eosrio.io:8092
 ```
 
-That is all a chain-API ([Path A](#path-a-api-node-without-full-history)) node requires. For **State History / Hyperion**, add the [Path B](#path-b-api-node-with-full-history) plugin block. For optional performance and billing tuning (`read-only-read-window-time-us`, `disable-subjective-*-billing`, etc.), see [Recommended API-node settings](#recommended-api-node-settings). To take snapshots, temporarily enable `eosio::producer_api_plugin` behind a proxy that filters `/v1/producer/`.
+That is all a read-only chain-API ([Path A](#path-a-api-node-without-full-history)) node requires. For **State History / Hyperion**, add the [Path B](#path-b-api-node-with-full-history) plugin block. For optional performance and billing tuning (`read-only-read-window-time-us`, `disable-subjective-*-billing`, etc.), see [Recommended API-node settings](#recommended-api-node-settings). To take snapshots, temporarily enable `eosio::producer_plugin` plus `eosio::producer_api_plugin` while the API remains private, then remove both again.
 
 :::caution
-Do not carry over `producer-threads` or any [option removed in Spring/Leap 5](#remove-options-that-were-dropped-in-springleap-5) — `nodeos` will refuse to start. For **testnet**, use `chain-id = 1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f` with testnet peers/genesis.
+Do not carry over `producer-threads`, `chain-id`, or any [option removed in Spring/Leap 5](#remove-options-that-were-dropped-in-springleap-5) — `nodeos` will refuse to start. For **testnet**, use trusted testnet genesis/snapshot state and peers, then verify the expected testnet ID through `get_info`.
 :::
 
-The full annotated reference is the official [node-template `config.ini`](https://github.com/telosnetwork/node-template/blob/master/config.ini).
+The maintained read-only role profiles are in the official
+[Telos node-template repository](https://github.com/telosnetwork/node-template).
 
 ---
 
@@ -412,10 +415,9 @@ plugin = eosio::state_history_plugin
 state-history-dir = /path/to/state-history
 trace-history = true
 chain-state-history = true
-state-history-endpoint = 0.0.0.0:18999   # SHiP websocket (consumed by Hyperion/indexers)
-
-# If this node supports IBC / finality data consumers, also set:
-# finality-data-history = true
+finality-data-history = true
+vote-threads = 0
+state-history-endpoint = 127.0.0.1:18999 # use a private IP for remote indexers
 ```
 
 The full block log from genesis is kept by default — no extra block-log option is required. Keep your existing `blocks/` directory in place across the upgrade.
@@ -535,4 +537,5 @@ p2p-peer-address = p2p-mainnet.tlos.news:9876
 - **Telos GitHub:** [github.com/telosnetwork](https://github.com/telosnetwork)
 - **Developer Telegram:** [Telos Zero / Dapps development](https://t.me/dappstelos)
 
-For the general (non-exchange) node walkthrough and the earlier Leap 5.0 migration notes, see [Run a Non Block Producing Node](https://docs.telos.net/nodes/non-bp-nodes/run_a_telos_node/).
+For the current relay, read-only API, and SHiP role walkthrough, see
+[Run a Non-Block-Producing Node](/nodes/non-bp-nodes/run_a_telos_node/).

--- a/docs/nodes/non-bp-nodes/run_a_telos_node.mdx
+++ b/docs/nodes/non-bp-nodes/run_a_telos_node.mdx
@@ -1,550 +1,234 @@
 ---
-title: 'Run a Non Block Producing Node'
+title: 'Run a Non-Block-Producing Node'
 displayed_sidebar: devBar
+description: Configure a TelosZero vote relay, read-only API, or State History node after Savanna activation.
 sidebar_position: 1
-hide_table_of_contents: true
+hide_table_of_contents: false
 ---
 
-# Run a Node
+# Run a Non-Block-Producing Node
 
-[This](https://github.com/telosnetwork/node-template)  repo contains scripts for easy management of the node, some helpful readme notes, and the P2P list for both mainnet and testnet.
+This guide covers steady-state nodes on a Telos network where Savanna instant
+finality is already active. Use it for vote relays, read-only APIs, and State
+History (SHiP) services. A backup producer is a producer-capable host and must
+instead follow the [BP setup guide](/nodes/bp-nodes/setting-up-telos-validator-nodes/)
+and [finalizer safety rules](/nodes/bp-nodes/finalizer-setup/).
 
+## Choose one role
 
-## Telos node template files
+| Role | Finalizer votes | Signing keys | Intended workload |
+| --- | ---: | --- | --- |
+| Vote relay / sentry | `vote-threads = 4` | None | Carry P2P blocks, transactions, and finalizer votes between private producers and public peers |
+| Read-only API | `vote-threads = 0` | None | Serve chain API calls behind a TLS reverse proxy |
+| SHiP | `vote-threads = 0` | None | Stream traces, chain state, and finality data to trusted indexers |
 
-To simplify the process of running a Telos node, the following example will use node template files. These examples assume you're running Ubuntu 22.04.
+Only relays on a finalizer's P2P path need vote processing. Pure API and SHiP
+nodes should not load a BLS key, `producer-name`, `producer_plugin`, or a
+`finalizers-dir`.
 
-For a local dev node, check out the [Dev setup](https://github.com/telosnetwork/node-template/blob/master/DEV_SETUP.md).
+## 1. Install TelosZero Core
 
-## Setup directories
+Follow [Install TelosZero Core](/nodes/bp-nodes/installing-node-software/) and
+verify the approved package checksum and full version. The current templates
+target [TelosZero Core 1.2.2](https://github.com/telosnetwork/teloszero-core/releases/tag/teloszero-v1.2.2).
 
-Create a directory to store nodes and binaries in, setup a log directory and set their permissions. Let's assume your user is named `telos` and you want to store everything in a directory named `/telos`.
+Do not install Leap 4/5 for a new Telos node, and do not carry forward removed
+options such as `producer-threads`, `chain-id`, `wasm-runtime = wabt`, or the
+legacy `history_plugin`.
 
-Note, if you wish to have the node keep it's logs in it's own node directory, you can skip the creation and chown of the /var/log/nodeos directory.
+## 2. Prepare an instance
 
-```shell
-sudo mkdir /telos
-sudo mkdir /var/log/nodeos
-sudo chown telos: /telos
-sudo chown telos: /var/log/nodeos
-```
-
-## Install packages
-``` shell
-sudo apt install schedtool
-```
-
-## Download this template
-To create a new node at /telos/nodes/testnet1:
-```shell
-mkdir -p /telos/nodes/testnet1
-cd /telos/nodes/testnet1
-curl -L https://api.github.com/repos/telosnetwork/node-template/tarball/master | tar -xvz --strip=1
-```
-
-## Setup peers
-
-Copy the contents of the peers.ini from mainnet/testnet directory into the config.ini from the template, adding/removing peers to suit your region/needs.
-```shell
-echo >> config.ini
-echo "#TESTNET PEERS:" >> config.ini
-cat testnet/peers.ini >> config.ini
-```
-
-Pick a version to download from https://github.com/EOSIO/eos/releases.
-You can find more up to date peers via the [EOS Nation](https://eosnation.io/) BP validator tool for either [testnet](https://validate.eosnation.io/telostest/) or [mainnet](https://validate.eosnation.io/telos/).
-
-## Install latest Leap AntelopeIO binaries (if needed)
-
-Pick a version to download from https://github.com/AntelopeIO/leap/releases.
-
-Select a stable release, likely the `latest` tagged one (not RC/Release Candidate) which is built for your OS Version.
-```shell
-wget https://github.com/AntelopeIO/leap/releases/download/v4.0.1/leap_4.0.1-ubuntu22.04_amd64.deb
-sudo apt install ./leap_4.0.1-ubuntu22.04_amd64.deb
-```
-
-## Move binaries
-Now find where the binaries installed and move the nodeos binary to somewhere that won't be changed when you install the next version, it's likely they are in `/usr/bin`, this will allow you to run a different version on this same machine.
-
-The strategy here is that in the `/telos/leap` directory you have a directory for each version you may want to run on this machine, inside each directory is the `nodeos` binary matching that version.  To update nodes you'll just have to change the version in the specific node's `node_config` file and restart it, as well as take any other measures needed for that version upgrade (reindex, etc..).
-
-Note, installing the `.deb` file will put all the binaries (`nodeos`,`cleos`,`keosd`) in your path, if you simply use the binary name (e.g. `nodeos` without a path) it will use the most recently installed version.  For the purposes of running a node, the only binary which needs to be copied and versioned in this way would be `nodeos`.
-```shell
-mkdir -p /telos/leap/4.0.1
-cp -a /usr/bin/nodeos /telos/leap/4.0.1/
-```
-
-### Set node version
-Now you know the path to the binaries, change that in the `node_config` file, set the `BUILD_ROOT` variable
-```
-BUILD_ROOT="/telos/leap/4.0.1"
-```
-
-### Distribute CPU load
-The `start.sh` script will pin the `nodeos` process to a specific CPU core, this optimizes performance.  If you are running multiple nodes on the same host and do not change this setting you will have all nodes fighting over the same CPU core so you should make sure each node has a different value set.
-
-To determine how many cores you have, run `cat /proc/cpuinfo | grep processor` and then pick one that's not already configured on other nodes and set it in the `node_config` file:
-```
-CPU="0"
-```
-
-__Optional: Configure to write logs locally to the node's directory if you prefer instead of the system-wide `/var/log/nodeos` path as mentioned above__
-Set the `LOCALIZE_LOG` flag to true in the `node_config` file.
-```
-LOCALIZE_LOG=true
-```
-
-## Setup config.ini
-### Review
-Review the config.ini file to get familiar with it, adjust as needed.
-
-### Set the ports
-Make sure you set the ports to ones that are not already in use on this server by other nodes.
-
-## Start the node
-To start the node you have two options:
-
- - Start from genesis and sync the whole history
- - Start from a given snapshot
-  
-### Start from genesis
-```shell
-cd /telos/nodes/testnet1
-./start.sh --genesis-json ./testnet/genesis.json
-```
-### Start from snapshot
-Be sure to get the latest snapshot for either [mainnet](https://snapshots.telosunlimited.io/) or [testnet](https://snapshots.eosnation.io/)
-```shell
-cd /telos/nodes/testnet1
-wget https://snapshots.telosunlimited.io/telos-mainet-20230615-blk-283714511.tar.gz | tar -zxvf
-```
-From there you are ready to start your node! Run `./start.sh` with the `--snapshot` flag and the name of the snapshot binary.
-```shell
-./start.sh --snapshot /snapshot-10e680cfae6365b7839abffc5239cb874b61b64274a6cafd051a1610a9d0c08f.bin
-```
-
-## Configure public access
-This assumes the node operator has reasonable system administration skills, which should be expected of a Telos block producer.
-### P2P
-Point DNS at the server and expose the p2p port (`p2p-listen-endpoint`), this is your seed/p2p endpoint and is only tcp, it does not require anything in front of it.  If you wish you can use a tcp load balancer such as haproxy in front of the p2p, then you'll point the DNS at the load balancer.
-### API
-Install something like nginx or haproxy and point DNS at it for your API endpoint, configure it for SSL.
-
-A popular option is to put nginx in front of it using auto-renewing and free SSL certs from Let's Encrypt - https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-18-04.
-
-You'll want to configure nginx in this case for a reverse proxy, and point it at your `http-server-address`.
-
----
-
-## Telos LEAP v5.0 Upgrade Guide
-
-This guide provides step-by-step instructions for upgrading Telos nodes running nodeos versions older than LEAP 5.0 to version 5.0 or later, while maintaining all block and state history.
-
-For the latest LEAP 5.0 release notes, visit the [AntelopeIO LEAP Releases](https://github.com/AntelopeIO/leap/releases/tag/v5.0.3).
-
----
-
-## Important Notice
-
-**LEAP 5.0 requires a restart from snapshot** due to structural changes in state memory storage. This is a mandatory requirement - you cannot simply upgrade the binary in place. Plan for downtime during this upgrade process.
-
----
-
-## Pre-Upgrade Checklist
-
-Before beginning the upgrade process, ensure you have:
-
-- [ ] A stable backup of your current node configuration
-- [ ] Sufficient disk space for the snapshot (typically 1-3 GB for Telos Mainnet)
-- [ ] Access to your node's configuration files
-- [ ] Reviewed your current `config.ini` for deprecated parameters
-- [ ] Scheduled maintenance window with appropriate downtime
-- [ ] Downloaded the latest LEAP 5.x release for your platform
-
----
-
-## Key Changes in LEAP 5.0
-
-### Deprecations & Removals
-
-#### Deferred Transactions Removed
-Deferred transactions were previously deprecated and have been **completely removed** in LEAP 5.0. No new deferred transactions may be created, and existing deferred transactions will be blocked from executing.
-
-#### Get Block Header State Deprecated
-As of LEAP v5.0.0, the `v1/chain/get_block_header_state` endpoint is deprecated and will be removed in LEAP v6.0.0. Update any applications or scripts that rely on this endpoint.
-
----
-
-## Upgrade Process
-
-### Step 1: Download Latest LEAP Release
-
-Download the appropriate LEAP 5.x package for your operating system from the [AntelopeIO LEAP Releases](https://github.com/AntelopeIO/leap/releases) page.
-
-### Step 2: Create Snapshot from Current Node
-
-While your current node is still running, create a snapshot:
+The maintained [Telos node-template repository](https://github.com/telosnetwork/node-template)
+contains separate profiles for vote relays, APIs, and SHiP. Clone it and create
+a service account:
 
 ```bash
-curl -X POST http://127.0.0.1:8888/v1/producer/create_snapshot
+git clone https://github.com/telosnetwork/node-template.git
+cd node-template
+
+id -u telos >/dev/null 2>&1 \
+  || sudo useradd --system --home-dir /var/lib/telos --shell /usr/sbin/nologin telos
 ```
 
-Wait for the response containing the snapshot filename. The output will look like:
-```json
-{
-  "snapshot_name": "snapshot-0abc123...xyz.bin"
-}
-```
-
-**Important:** Make note of this filename - you'll need it in Step 6.
-
-**Alternative:** You can also download a recent snapshot from Telos community providers:
-- [Telos Mainnet Snapshots](https://snapshots.eosnation.io/)
-- Be sure to select a snapshot from Telos Mainnet v6
-
-### Step 3: Stop Your Node
-
-Stop the currently running nodeos process:
+Choose an instance name prefixed by its network, such as `mainnet-relay-a`,
+`mainnet-api`, or `mainnet-ship`. Create root-owned configuration and writable
+instance data directories:
 
 ```bash
-# If using systemd
-sudo systemctl stop nodeos
+export INSTANCE=mainnet-api
 
-# Or if running manually, find and kill the process
-pkill nodeos
+sudo install -d -o root -g telos -m 0750 "/etc/telos/$INSTANCE"
+sudo install -d -o telos -g telos -m 0750 "/var/lib/telos/$INSTANCE"
 ```
 
-Wait until the process has fully terminated before proceeding.
+## 3. Render and review the role profile
 
-### Step 4: Remove Old LEAP Package
-
-For Ubuntu/Debian:
-```bash
-sudo apt-get remove -y leap
-```
-
-For other package managers, use the appropriate removal command. If running nodeos from a local bin, delete it to avoid confusion.
-
-### Step 5: Remove State Memory File
-
-Remove **only** the `shared_memory.bin` file from your nodeos data directory:
+Render exactly one network and role:
 
 ```bash
-# Default location
-rm ~/.local/share/eosio/nodeos/data/state/shared_memory.bin
-
-# Or if using custom data directory specified by --data-dir
-rm /path/to/your/data-dir/state/shared_memory.bin
+./scripts/render-config.sh mainnet api "$INSTANCE" /tmp/telos-config.ini
 ```
 
-**Important:** Do NOT remove other files in the data directory, especially:
-- `blocks/` directory (contains your block log)
-- `state-history/` directory (if running state history plugin)
-- `snapshots/` directory
+Valid roles are `vote-relay`, `api`, and `ship`. The renderer appends endpoints
+currently marked verified by the Telos validator service. Treat that list as a
+starting point: curate for operator and geographic diversity and monitor every
+peer.
 
-### Step 6: Install New LEAP Package
-
-Install the LEAP 5.0.3 package:
-
-For Ubuntu/Debian:
-```bash
-sudo apt-get install -y ./leap_5.0.3_amd64.deb
-```
-
-### Step 7: Update Configuration File
-
-Edit your `config.ini` file to comply with LEAP 5.0 requirements (see Configuration Changes section below).
-
-### Step 8: Restart Node with Snapshot
-
-Start nodeos with the snapshot file from Step 2:
-
-```bash
-nodeos --snapshot /path/to/snapshots/snapshot-0abc123...xyz.bin \
-       --data-dir /path/to/your/data-dir \
-       --config-dir /path/to/your/config-dir \
-       [... other existing arguments ...]
-```
-
-**Note:** The `--snapshot` argument only needs to be provided on the **first launch** after upgrading to LEAP 5.x. Remove it from subsequent starts. If you are utilizing the node startup script found here (https://github.com/telosnetwork/node-template) you can pass ./run.sh --snapshot /path/to/snapshot.bin
-
-### Step 9: Verify Node Operation
-
-Monitor your node's log output and verify:
-
-- Node is replaying from the snapshot
-- Blocks are syncing properly
-- No configuration errors appear
-- API endpoints are responding (if configured)
-
-```bash
-# Check node info
-curl http://127.0.0.1:8888/v1/chain/get_info
-
-# Monitor logs
-tail -f /path/to/nodeos.log
-```
-
----
-
-## Required Configuration Changes
-
-The following configuration changes are **mandatory** for LEAP 5.0 nodes.
-
-### Remove Unsupported Parameters
-
-**Remove or comment out** the following parameters from your `config.ini`. These parameters are no longer supported and will prevent nodeos from starting:
+Review the rendered configuration before installation. Every role uses:
 
 ```ini
-# REMOVE THESE PARAMETERS:
-# cpu-effort-percent
-# last-block-cpu-effort-percent
-# last-block-time-offset-us
-# produce-time-offset-us
-# max-nonprivileged-inline-action-size
-# max-scheduled-transaction-time-per-block-ms
-# disable-subjective-billing
+chain-state-db-size-mb = 32768
+protocol-features-dir = /var/lib/telos/<INSTANCE>/protocol_features
+plugin = eosio::chain_plugin
+plugin = eosio::net_plugin
 ```
 
-### Enable Subjective Billing (APIs and Block Relays)
+The 32768 MiB chain-state capacity is a starting point for a host with 64 GB RAM.
+Keep it below usable physical memory and increase it deliberately as measured
+state grows.
 
-If you're running an API node or block relay, you must enable subjective billing by adding:
+### Vote relay
+
+A vote relay must accept and forward finalizer votes but has no signing keys:
 
 ```ini
-disable-subjective-api-billing = false
-disable-subjective-p2p-billing = false
-```
-
----
-
-## Recommended Configuration Changes
-
-### Transaction Time Windows
-
-Based on production testing and performance data:
-
-```ini
-# Comment out or remove max-transaction-time
-# max-transaction-time = 30
-
-# Set read-only window time (for LEAP 4.x and later)
-read-only-read-window-time-us = 165000
-```
-
-**Rationale:** Transactions can exceed the default 30ms limit in production. Removing `max-transaction-time` allows the on-chain transaction deadline to be the limiting factor. The read-only window needs to be larger because read actions execute in parallel.
-
----
-
-## New Features & Options in LEAP 5.0
-
-### New Command Line Options
-
-**Sync Peer Limit:**
-```bash
---sync-peer-limit 3
-```
-Limits the number of peers to sync from. Default is 3.
-
-**EOS-VM-OC Auto Mode:**
-```bash
---eos-vm-oc-enable auto
-```
-The new `auto` mode automatically uses optimized compilation (OC) when building blocks, applying blocks, executing transactions, and executing contracts on `eosio.*` accounts. This is now the **default behavior**.
-
-### New Config Options
-
-**HTTP Category Address:**
-```ini
-http-category-address = 127.0.0.1:8888
-```
-Can be specified multiple times to configure different category addresses.
-
-### Modified Option Behaviors
-
-**Multiple P2P Endpoints:**
-```ini
+http-server-address = 127.0.0.1:8888
 p2p-listen-endpoint = 0.0.0.0:9876
-p2p-listen-endpoint = 0.0.0.0:9877
-p2p-server-address = your-node.telos.net:9876
-p2p-server-address = your-node.telos.net:9877
+vote-threads = 4
+
+plugin = eosio::http_plugin
+plugin = eosio::chain_plugin
+plugin = eosio::net_plugin
 ```
 
-**Sync Fetch Span:**
-- Default changed from 100 to 1000 blocks
+Place public peers only on relays and other non-producing nodes. A private
+producer should connect only to BP-controlled relays.
 
-**Disable Replay Opts:**
-- Automatically set to `true` if state history plugin is enabled
+### Read-only API
 
-**Read-Only Threads:**
-- Can now be set to a maximum of 128 (increased from previous limits)
+Bind `nodeos` to loopback and expose it through a hardened TLS reverse proxy:
 
-**HTTP Max Response Time:**
-- Default changed from 30ms to 15ms
-
----
-
-## Telos-Specific Considerations
-
-### Chain ID
-
-Ensure your configuration has the correct chain ID for your target network:
-
-**Telos Mainnet:**
 ```ini
-chain-id = 4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11
+http-server-address = 127.0.0.1:8888
+p2p-listen-endpoint = 0.0.0.0:9876
+vote-threads = 0
+api-accept-transactions = false
+
+plugin = eosio::http_plugin
+plugin = eosio::chain_plugin
+plugin = eosio::chain_api_plugin
+plugin = eosio::net_plugin
 ```
 
-**Telos Testnet:**
-```ini
-chain-id = 1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f
-```
+Do not enable wildcard CORS on a public RPC. Configure exact trusted origins at
+the reverse proxy only when a browser application requires them.
 
-### P2P Peer List
+### State History (SHiP)
 
-Update your P2P peers for Telos networks:
-
-**Telos Mainnet P2P Peers:**
-```ini
-# amsterdam: NL, Amsterdam
-p2p-peer-address = telos.eu.eosamsterdam.net:9120
-# bp.adex: DE, Falkenstein
-p2p-peer-address = p2p-telos.a-dex.xyz:9976
-# bp.boid: ES, Tenerife, Canary Islands, Spain
-p2p-peer-address = telos.p2p.boid.animus.is:5252
-# eosauthority: DE, Falkenstein
-p2p-peer-address = node-telos.eosauthority.com:10311
-# eosphereiobp: AU, Sydney
-p2p-peer-address = peer1-telos.eosphere.io:9876
-# eosphereiobp: AU, Sydney
-p2p-peer-address = peer2-telos.eosphere.io:9876
-# eosriobrazil: BR, Rio de Janeiro
-p2p-peer-address = telos.eosrio.io:8092
-# guild.nefty: FI, Finland
-p2p-peer-address = telos-public-seed.neftyblocks.com:9877
-# kainosblkpro: US, Texas
-p2p-peer-address = p2p.kainosbp.com:9876
-# mosaicblocks: FI, Helsinki
-p2p-peer-address = mainnet.mosaicblocks.com:9876
-# nation.tlos: CA, Canada
-p2p-peer-address = telos.seed.eosnation.io:9876
-# orbitalblock: CA, Beauharnois
-p2p-peer-address = p2p-telos-mainnet.orbitalblock.com:9876
-# telosarabia1: DE, Munich
-p2p-peer-address = p2p.telosarabia.net:9876
-# telosindiabp: US, US
-p2p-peer-address = p2p.telos.blocksindia.com:7776
-# telosunlimit: US, St.Louis
-p2p-peer-address = p2p.telosunlimited.com:9876
-# veradox12321: FI, Finland
-p2p-peer-address = veradox.xyz:9877
-# votetelosusa: US, Greenville,SC,USA
-p2p-peer-address = telos.p2p.eosusa.io:9876
-# Add additional reliable Telos peers
-```
-
-### State History Configuration
-
-If maintaining full state history for Telos dApps and indexers:
+Use SHiP only on a dedicated indexing node and keep its WebSocket endpoint on
+loopback or a private interface:
 
 ```ini
+vote-threads = 0
+api-accept-transactions = false
+
+plugin = eosio::http_plugin
+plugin = eosio::chain_plugin
+plugin = eosio::chain_api_plugin
+plugin = eosio::net_plugin
 plugin = eosio::state_history_plugin
-state-history-dir = /path/to/state-history
+
+state-history-endpoint = 127.0.0.1:8080
 trace-history = true
 chain-state-history = true
-state-history-endpoint = 0.0.0.0:8080
+finality-data-history = true
+state-history-dir = state-history
 ```
 
----
+`finality-data-history = true` makes Savanna finality data available to SHiP
+consumers. Plan storage and retention for the full history workload.
 
-## Troubleshooting
+Install the reviewed profile read-only to the service account:
 
-### Node Won't Start
-
-**Error: Unsupported configuration parameter**
-- Solution: Remove all deprecated parameters listed in the Required Configuration Changes section
-
-**Error: Cannot load snapshot**
-- Solution: Verify snapshot file exists and path is correct
-- Solution: Ensure snapshot is compatible (any version snapshot works with LEAP 5.0)
-
-**Error: Shared memory file exists**
-- Solution: Ensure you removed `shared_memory.bin` in Step 5
-
-### Performance Issues
-
-**Slow sync speed:**
-- Increase `sync-peer-limit` to allow more sync peers
-- Verify `sync-fetch-span = 1000` in config
-- Check network connectivity to P2P peers
-
-**API timeouts:**
-- Adjust `read-only-read-window-time-us` to 165000 or higher
-- Increase `read-only-threads` based on CPU availability
-- Consider adjusting `http-max-response-time-ms` if needed
-
----
-
-## Post-Upgrade Verification
-
-After upgrading, verify your node is functioning correctly:
-
-### Check Node Info
 ```bash
-curl http://127.0.0.1:8888/v1/chain/get_info
+sudo install -o root -g telos -m 0640 /tmp/telos-config.ini \
+  "/etc/telos/$INSTANCE/config.ini"
+sudo install -o root -g telos -m 0640 logging.json \
+  "/etc/telos/$INSTANCE/logging.json"
 ```
 
-Verify the output shows:
-- Correct `chain_id` for Telos Mainnet or Testnet
-- `head_block_num` is increasing
-- `server_version` matches your LEAP 5.x version
+## 4. Bootstrap from trusted chain state
 
-### Test API Endpoints
+`chain-id` is not a valid `nodeos` option. The genesis or snapshot state selects
+the network. For a new mainnet or testnet data directory, obtain a recent
+snapshot from a trusted provider, verify its published checksum, and start it
+once in the foreground:
+
 ```bash
-# Get account info
-curl -X POST http://127.0.0.1:8888/v1/chain/get_account \
-  -d '{"account_name":"eosio"}'
-
-# Get table rows
-curl -X POST http://127.0.0.1:8888/v1/chain/get_table_rows \
-  -d '{"code":"eosio.token","scope":"eosio.token","table":"stat"}'
+sudo -u telos /usr/bin/nodeos \
+  --config-dir "/etc/telos/$INSTANCE" \
+  --data-dir "/var/lib/telos/$INSTANCE" \
+  --snapshot "/var/lib/telos/$INSTANCE/snapshots/<snapshot-file>.bin"
 ```
 
-### Monitor Logs
+Stop cleanly after the snapshot loads. Do not retain `--snapshot` for normal
+restarts.
+
+## 5. Run the instance with systemd
+
+Install the instance service supplied by node-template:
+
 ```bash
-tail -f /path/to/nodeos.log
+sudo install -o root -g root -m 0644 systemd/telos-nodeos@.service \
+  /etc/systemd/system/telos-nodeos@.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now "telos-nodeos@$INSTANCE"
+sudo systemctl status "telos-nodeos@$INSTANCE"
+sudo journalctl -u "telos-nodeos@$INSTANCE" -f
 ```
 
-Look for:
-- No error messages
-- Successful block processing
-- P2P connection messages
-- State history updates (if enabled)
+The instance service uses `/etc/telos/%i` and `/var/lib/telos/%i`, preventing a
+mainnet, testnet, API, relay, or SHiP process from accidentally sharing runtime
+state.
 
-### Verify State History (if applicable)
+## 6. Verify network, sync, and finality
+
+Query the loopback API:
+
 ```bash
-curl http://127.0.0.1:8080/v1/chain/get_info
+curl -s http://127.0.0.1:8888/v1/chain/get_info | jq '{
+  chain_id,
+  server_full_version_string,
+  head_block_num,
+  last_irreversible_block_num,
+  head_block_time,
+  lib_lag: (.head_block_num - .last_irreversible_block_num)
+}'
 ```
 
----
+Expected chain IDs:
 
-## Support & Resources
+```text
+Mainnet: 4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11
+Testnet: 1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f
+```
 
-### Telos Resources
-- **Website:** https://www.telos.net/
-- **Documentation:** https://docs.telos.net/
-- **GitHub:** https://github.com/telosnetwork
-- **Telegram:** Telos Network Telegram Dev Topic
+Confirm that:
 
-### LEAP Resources
-- **LEAP GitHub:** https://github.com/AntelopeIO/leap
-- **LEAP Releases:** https://github.com/AntelopeIO/leap/releases
+- the chain ID and approved full version are exact;
+- head and irreversible blocks advance and the node reaches network head;
+- P2P peers remain diverse and stable;
+- a vote relay carries live vote traffic in both directions;
+- API nodes reject transaction submission as intended;
+- SHiP consumers receive traces, chain state, and finality data;
+- logs contain no persistent fork, database, vote, or peer errors.
 
----
+Alert on sustained deviations from the network's normal head-to-LIB lag rather
+than one hard-coded threshold.
 
-Upgrading to LEAP 5.0 provides improved performance, better resource management, and sets the foundation for future Telos network enhancements. While the snapshot requirement adds complexity to the upgrade process, following this guide will ensure a smooth transition while maintaining all your block and state history.
+## Ongoing operations
 
-Always test the upgrade process in a non-production environment first, and ensure you have proper backups before proceeding with production nodes.
-
-**Good luck with your upgrade, and welcome to LEAP 5.0 on Telos!**
-
+- Refresh and review public peers through node-template's peer updater.
+- Keep TelosZero upgrades, snapshot procedures, and storage growth under change control.
+- Back up configuration and indexing data according to role, but never introduce a BLS key or `safety.dat` on these non-producing profiles.
+- Keep public RPC, P2P, and SHiP firewall policies separate and least-privileged.

--- a/docs/nodes/types-of-nodes.mdx
+++ b/docs/nodes/types-of-nodes.mdx
@@ -1,59 +1,45 @@
 ---
 sidebar_position: 2
 displayed_sidebar: devBar
-title: "Types of Nodes"
-hide_table_of_contents: true
+title: 'Types of Nodes'
+hide_table_of_contents: false
 ---
 
 # Types of Nodes
 
-The main component of the Telos blockchain network is `nodeos` (node + Antelope). `nodeos` is the core node daemon that runs on every Telos node in the network and is distributed as part of the Antelope software suite. Each node can be configured to function as a
+The same TelosZero Core `nodeos` binary can serve several roles. Security, plugins, storage, and finalizer settings differ by role, so production operators should not combine every workload on one host.
 
-1. Block Producing node, or
-2. Non-producing node (depending on the plugin's implemented).
+| Role | Produces blocks | BLS key | Vote threads | Public service |
+|---|---:|---:|---:|---|
+| Private producer/finalizer | Yes, when scheduled | One unique key per host | `4` | No |
+| Backup producer/finalizer | Paused until an exclusive failover | Different pre-registered key | `4` | No |
+| Vote relay/sentry | No | No | `4` | P2P as required |
+| Chain API | No | No | `0`/unset | HTTP through a hardened proxy |
+| State History (SHiP) | No | No | `0`/unset unless also a vote relay | WebSocket to trusted consumers |
+| Seed/P2P | No | No | `0`/unset unless also a vote relay | P2P |
 
-### Producing Nodes
-Producing nodes are configured for block production. They connect to the Telos peer-to-peer network and actively produce new blocks. Producing nodes produce blocks on the mainnet, if they are an assigned block producer as part of the active block producing schedule.
+## Producer/finalizer nodes
 
-Each producer node (top-21 DPoS) validates all blocks and transactions it receives. The nodes of elected (top-21 DPoS) producers take turns in bundling new transactions into blocks and broadcasting them to the network.
+An active BP's private producer signs scheduled blocks with a K1 key and finalizer votes with a BLS key. The BLS key, `vote-threads`, and persistent `finalizers-dir` make this role different from a legacy producer configuration.
 
-### Non-producing nodes
-Non-producing nodes also connect to the Telos peer-to-peer network, but they are not actively producing blocks. Instead, they are connected and synchronised with other peers from the Telos network.  Non-producing nodes are useful for:
-- proxy nodes, 
-- relaying API calls (API endpoints), 
-- validating transactions, 
-- monitoring the blockchain state history, and 
-- broadcasting information to other nodes.
+Use minimal plugins and private networking. Public RPC, history, and indexing workloads belong on separate hosts. See [Set Up a Telos Block Producer](/nodes/bp-nodes/setting-up-telos-validator-nodes/).
 
-`nodeos` enables you to set up a device for local development as a single node blockchain network.
-Non-producing nodes exposes one or more services publicly or privately by enabling one or more `nodeos` plug-ins, except the `producer_plugin`.
+## Vote relay/sentry nodes
 
-The behaviour of `nodeos` is determined mainly by which plug-ins are loaded and which plug-in options are selected. Some plug-ins are mandatory (`chain_plugin`, `net_plugin`, and `producer_plugin`) while others are optional. 
+Relays protect private producers from direct internet exposure and provide redundant P2P paths. Every intermediate relay that must carry Savanna votes needs a positive `vote-threads` setting, normally `4`, but it does not hold a BLS key.
 
-## Leap
-Leap is the blockchain node software and supporting tools that impelments the Antelope protocol. Download the source [here](https://github.com/AntelopeIO/leap).
+A generic public seed that is not on a producer's vote path can leave vote processing disabled.
 
-## Telos Nodes
-It's not uncommon to encounter a variety of different nodes such as: API node, Producer node, History node, and Seed node. All nodes update an internal database by applying the transactions as they arrive on incoming blocks. The difference between the node type lies in the amount of history they keep track of and the functionality they provide.
+## API nodes
 
-After proper installation of released Antelope.io core software, each node is implemented by the same executable, however, each node would need to set up different configurations to start. Although a block producing node can have full state history or run as an API endpoint, this would be a waste of resources. Block producing nodes should run with minimal plug-ins. Also, producing nodes should not have open network ports. We strongly recommend all node service providers to run and maintain their own nodes for reliability and security reasons.
+API nodes expose the chain API used by wallets, applications, exchanges, and monitoring. Bind `nodeos` HTTP locally and place TLS, access control, rate limits, and caching on a reverse proxy. API nodes do not need producer or finalizer keys.
 
-### API Node
----------                                       --------
-API nodes provide network services to client applications. They typically have account transaction histories accessible though API calls, but can vary in the amount of available history.
+## State History nodes
 
-### History API Node
---------                                        ---------
-State History (or History API) nodes are API nodes with a complete transaction history of all accounts that are used for querying transaction and account data from. There are various types of history API nodes, Hyperion being the most common on Telos.
+SHiP nodes enable `eosio::state_history_plugin` and stream block, trace, table-delta, and optional finality history to Hyperion or other indexers. They require substantially more storage and I/O than a chain-only API node.
 
-### Seed Node   
------------                                     --------------
-Seed nodes are for peering with other nodes on the P2P network. They offer blocks to peers over the P2P protocol and accept incoming P2P connections. Seed nodes are the first nodes contacted by a freshly started node. In that sense, they serve as an entry point into the network.
+Do not use the removed `history_plugin`. For EVM history, see [telos-reth](/nodes/non-bp-nodes/telos-reth/).
 
-Once a node has entered the network it will receive additional node addresses from its peers so all nodes can connect to each other. A seed node can also be an API node. The seed nodes are used only to locate or find complete nodes that are running the Telos Blockchain client.
+## Seed/P2P nodes
 
-When a new node wants to gain access to the network, it must connect with a seed node, which is a Telos client that is always active and has a static IP address. This client operates as a gateway to the Telos network. It is one of the first connections that Telos clients make at the beginning.
-
-Seed nodes play an important role within the network, operating from highly trusted servers. They enable new clients to connect to the Telos network automatically and without the need for manual intervention by a user. There remaains a risk that a node may engage in malpractice that would result in a negative mpact on the network. Therefore, it is not recommended to place trust in a single seed node.
-
-A seed node can also be an API node and the P2P list for mainnet and testnet can be found at the [node-template repo](https://github.com/telosnetwork/node-template). The genesis.json is also available there.
+Seed nodes accept P2P connections and help new nodes discover and synchronize with the network. Use multiple independently operated peers and obtain the current list from [validators.telos.net](https://validators.telos.net/) or the [Telos node-template repository](https://github.com/telosnetwork/node-template). Avoid copying static peer lists from old guides.

--- a/docs/overview/advanced/consensus.mdx
+++ b/docs/overview/advanced/consensus.mdx
@@ -1,141 +1,99 @@
 ---
-sidebar_positon: 1
-description: >-
-    Learn more about the Telos
-    consensus mechanism.
-hide_table_of_contents: true
+sidebar_position: 1
+description: Learn how Telos combines DPoS block production with Savanna instant finality.
+hide_table_of_contents: false
 ---
 
-# Consensus
+# Telos Consensus
 
-## Overview
+Telos combines stakeholder-elected block production with **Savanna instant finality**. TelosZero Core implements both parts of the protocol.
 
-An Antelope blockchain is a highly efficient, deterministic, distributed state machine that can operate in a decentralized fashion. The blockchain keeps track of transactions within a sequence of interchanged blocks. Each block cryptographically commits to the previous blocks along the same chain. It is therefore intractable to modify a transaction recorded on a given block without breaking the cryptographic checks of successive blocks. This simple fact makes blockchain transactions immutable and secure.
+## Two coordinated roles
 
+### Block producers
 
-## Block Producers  
+TLOS stakeholders elect registered block producers (BPs). The active producer schedule determines which BP may publish at each time slot.
 
-Block producers are responsible for maintaining the blockchain by running nodes that perform block production and block validation. Producers are elected by TLOS holders. Each producer runs an instance of an Antelope node through nodeos service.  For this reason, producers that are on the active schedule to produce blocks are also called "active" or "producing" nodes.
+With the standard 21-producer schedule:
 
+- each producer receives a six-second production round;
+- up to 12 blocks are produced in that round;
+- the target block interval is 0.5 seconds.
 
-### The Need for Consensus  
+The scheduled BP signs each produced block with its K1 block-signing key. Every full-validation node independently checks the block and its transactions.
 
-Block validation presents a challenge among any group of distributed nodes. A consensus model must be in place to validate such blocks in a fault tolerant way within the decentralized system. Consensus is the way for such distributed nodes and users to agree upon the current state of the blockchain
+### Finalizers
 
-## Telos Consensus(DPoS = aBFT)
+Active BPs also operate Savanna finalizers. A finalizer uses a separate BLS key to vote on valid blocks continuously, including while another BP is producing.
 
-#### Layer 1: Telos Zero Consensus (aBFT)
-This layer ultimately decides which blocks, received and synced among the elected producers, eventually become final, and hence permanently recorded in the blockchain. It gets a schedule of producers proposed by the second layer  and uses that schedule to determine which blocks are correctly signed by the appropriate producer. For byzantine fault tolerance, the layer uses a two-stage block confirmation process by which a two-thirds supermajority of producers from the current scheduled set confirm each block twice. The first confirmation stage proposes a last irreversible block (LIB). The second stage confirms the proposed LIB as final. At this point, the block becomes irreversible. This layer is also used to signal producer schedule changes, if any, at the beginning of every schedule round.
+Finalizer votes propagate over the P2P network and are aggregated into quorum certificates (QCs). A QC proves that the configured finalizer-policy threshold supported a block. With 21 equally weighted finalizers, the Telos system contract sets the threshold to 15.
 
-#### Antelope Algorithmic Finality
-The Antelope consensus model achieves algorithmic finality (differing from the merely probabilistic finality that at best can be achieved in Proof of Work models) through the signatures from the chosen set of special participants (active producers) that are arranged in a schedule to determine which party is authorized to sign the block at a particular time slot. Changes to this schedule can be initiated by privileged smart contracts running on the Antelope blockchain, but any initiated changes to the schedule do not take effect until after the block that initiated the schedule change has been finalized by two stages of confirmations. Each stage of confirmations is performed by a supermajority of producers from the current scheduled set of active producers.
+The BLS key is separate from both the BP account authority and K1 block-signing key. BLS signatures are designed to aggregate many finalizer votes compactly.
 
-#### Layer 2: Delegated PoS (DPoS)
-The Delegated PoS layer introduces the concepts of tokens, staking, voting/proxying, vote decay, vote tallying, producer ranking, and inflation pay. This layer is also in charge of generating new producer schedules from the rankings generated from producer voting. This occurs in schedule rounds of approximately two minutes (126 seconds) which is the period it takes for a block producer to be assigned a timeslot to produce and sign blocks. The timeslot lasts a total of 6 seconds per producer, which is the producer round, where a maximum of 12 blocks can be produced and signed. The DPoS layer is enabled by WASM smart contracts.
-#### Stakeholders and Delegates
-The actual selection of the active producers (the producer schedule) is open for voting every schedule round and it involves all Antelope stakeholders who exercise their right to participate. In practice, the rankings of the active producers do not change often, though. The stakeholders are regular Antelope account holders who vote for their block producers of preference to act on their behalf as DPoS delegates. A major departure from regular DPoS, however, is that once elected, all block producers have equal power regardless of the ranking of votes obtained. In other DPoS models, voting power is proportional to the number of votes obtained by each delegate.
+## How a block becomes final
 
-## The Consensus Process
-The Antelope consensus process consists of two parts:
+At a high level:
 
-- Producer voting/scheduling - performed by the DPoS layer 2
-- Block production/validation - performed by the Telos Zero consensus layer 1
+1. The scheduled BP publishes a block.
+2. Full nodes validate the block.
+3. Finalizers make a safety-checked strong or weak vote.
+4. Votes travel through P2P peers and vote-capable relays.
+5. A supermajority of finalizer weight forms a QC.
+6. The certified block chain advances finality, and the last irreversible block (LIB) moves forward.
 
-These two processes are independent and can be executed in parallel, except for the very first schedule round after the boot sequence when the blockchain’s first genesis block is created.
+Savanna removes the legacy need to wait through full producer-schedule confirmation rounds. Under healthy network conditions, LIB remains close to head and advances continuously. Applications should still use the chain's authoritative finality signals—such as `last_irreversible_block_num` or transaction-finality APIs—instead of assuming that elapsed wall-clock time proves finality.
 
-## Producer Voting/Scheduling
-The voting of the active producers to be included in the next schedule is implemented by the DPoS layer. Strictly speaking, a token holder must first stake some tokens to become a stakeholder and thus be able to vote with a given staking power.
+## Strong and weak votes
 
-#### Voting Process
-Each Antelope stakeholder can vote for up to 30 block producers in one voting action. The top 21 elected producers will then act as DPoS delegates to produce and sign blocks on behalf of the stakeholders. The remaining producers are placed in a standby list in the order of votes obtained. The voting process repeats every schedule round by adding up the number of votes obtained by each producer. Producers that are not voted on get to keep their old votes.
+Finalizers maintain local safety information about prior votes and locks. A strong vote indicates the proposal satisfies the normal safe-extension conditions. A weak vote can preserve liveness during specific timing or branch conditions without violating the finalizer's safety rules.
 
-#### Producers schedule
-After the producers are voted on and selected for the next schedule, they are simply sorted alphabetically by producer name. This determines the production order. Each producer receives the proposed set of producers for the next schedule round within the very first block to be validated from the current schedule round that is about to start. When the first block that contains the proposed schedule is deemed irreversible by a supermajority of producers plus one, the proposed schedule becomes active for the next schedule round.
+The quorum-certificate logic validates the weight and consistency of strong and weak votes. Operators should treat sustained weak or missing votes as a diagnostic signal, not interpret a single warning in isolation.
 
-#### Production Parameters
-The Antelope block production schedule is divided equally among the elected producers. The producers are scheduled to produce an expected number of blocks each schedule round, based on the following parameters (per schedule round):
+## Finalizer policy
 
-Parameter	Description	Default	Layer
-P (producers)	number of active producers	21	2
-Bp (blocks/producer)	number of contiguous blocks per producer	12	1
-Tb (s/block)	Production time per block (s: seconds)	0.5	1
-It is important to mention that Bp (number of contiguous blocks per producer), and Tb (production time per block) are layer 1 consensus constants. In contrast, P (number of active producers) is a layer 2 constant configured by the DPoS layer, which is enabled by WASM contracts.
+The native finalizer policy identifies:
 
-The following variables can be defined from the above parameters (per schedule round):
+- a policy generation;
+- the finalizer threshold;
+- each finalizer's BP description, weight, and BLS public key.
 
-Variable	Description	Equation
-B (blocks)	Total number of blocks	Bp (blocks/producer) x P (producers)
-Tp (s/producer)	Production time per producer	Tb (s/block) x Bp (blocks/producer)
-T (s)	Total production time	Tp (s/producer) x P (producers)
-Therefore, the value of P, being defined at layer 2, can change dynamically in an Antelope blockchain. In practice, however, N is strategically set to 21 producers, which means that 15 producers are required for a two-thirds supermajority of producers plus one to reach consensus.
+Telos system-contract schedule updates keep the producer schedule and finalizer policy coordinated. A BP needs an active registered finalizer key before it is ready to join the active schedule.
 
-#### Production Default Values
-With the current defaults: P=21 elected producers, Bp=12 blocks created per producer, and a block produced every T=0.5 seconds, current production times are as follows (per schedule round):
+During a producer-schedule or BLS-key change, `nodeos` may report both active and pending finalizer policies. Operators must wait for a replacement key to become active in the native policy and produce advancing votes before retiring the old key.
 
-Variable	Value
-Tp: Production time per producer	Tp = 0.5 (s/block) x 12 (blocks/producer) ⇒ Tp = 6 (s/producer)
-T: Total production time	T = 6 (s/producer) x 21 (producers) ⇒ T = 126 (s)
-When a block is not produced by a given producer during its assigned time slot, a gap results in the blockchain.
+## Finalizer safety state
 
-## Block Lifecycle
-Blocks are created by the active producer on schedule during its assigned timeslot, then relayed to other producer nodes for syncing and validation. This process continues from producer to producer until a new schedule of producers is approved at a later schedule round. When a valid block meets the consensus requirements (see 3. Antelope Consensus), the block becomes final and is considered irreversible. Therefore, blocks undergo three major phases during their lifespan: production, validation, and finality. Each phase goes through various stages as well.
+Each producer-capable host stores voting history in `finalizers/safety.dat`. That history prevents a BLS key from signing an unsafe branch after a restart or recovery.
 
-#### Block Structure
-As an inter-chained sequence of blocks, the fundamental unit within the blockchain is the block. A block contains records of pre-validated transactions and additional cryptographic overhead such as hashes and signatures necessary for block confirmation, re-execution of transactions during validation, blockchain replays, protection against replay attacks, etc. (see block schema below).
+The file and key form a host-local safety boundary:
 
-__block schema__
+- never reuse one BLS key on two hosts;
+- never copy or roll back `safety.dat`;
+- when safety history is missing or uncertain, rotate to a never-used key.
 
-![BlockSchema](/img/block_schema.png)
+See [Finalizer Setup and Operations](/nodes/bp-nodes/finalizer-setup/) for the operator procedure.
 
+## DPoS governance and Savanna finality
 
-#### Block Production
-During each schedule round of block production, the producer on schedule must create Bp=12 contiguous blocks containing as many validated transactions as possible. Each block is currently produced within a span of Tb=500 ms (0.5 s). To guarantee sufficient time to produce each block and transmit it to other nodes for validation, the block production time is further divided into two configurable parameters:
+DPoS governance and Savanna consensus solve different problems:
 
-- maximum processing interval: time window to push transactions into the block (currently set at 200 ms).
-- minimum propagation time: time window to propagate blocks to other nodes (currently set at 300 ms).
-All loose transactions that have not expired yet, or dropped as a result of a previously failed validation, are kept in a local queue for both block inclusion and syncing with other nodes. During block production, the scheduled transactions are applied and validated by the producer on schedule, and if valid, pushed to the pending block within the processing interval. If the transaction falls outside this window, it is unapplied and rescheduled for inclusion in the next block. If there are no more block slots available for the current producer, the transaction is picked up eventually by another producing node (via the peer-to-peer protocol) and pushed to another block. The maximum processing interval is slightly less for the last block (from the producer round of Bp blocks) to compensate for network latencies during handoff to the next producer. By the end of the processing interval, no more transactions are allowed in the pending block, and the block goes through a finalization step before it gets broadcasted to other block producers for validation.
+- stakeholder voting and the Telos system contract select the producer schedule;
+- the schedule assigns block-production slots;
+- the corresponding finalizer policy certifies blocks and advances instant finality.
 
-Blocks go through various stages during production: apply, finalize, sign, and commit.
+Schedule selection remains dynamic, while finalizer-policy transitions are QC-protected so the network can change membership without abandoning safety.
 
-#### Apply Block
-Apply block essentially pushes the transactions received and validated by the producing node into a block. Internally, this step involves the creation and initialization of the block header and the signed block instance. The signed block instance simply extends the block header with a signature field. This field eventually holds the signature of the producer that signs the block. Furthermore, recent changes in Antelope allow multiple signatures to be included, which are stored in a header extensions field.
+## Inspect live consensus state
 
-#### Finalize Block
-Produced blocks need to be finalized before they can be signed, committed, relayed, and validated. During finalization, any field in the block header that is necessary for cryptographic validation is computed and stored in the block. This includes generating both merkle tree root hashes for the list of action receipts and the list of transaction receipts pushed to the block.
+```bash
+# Head and irreversible block
+cleos -u https://mainnet.telos.net get info
 
-#### Sign Block
-After the transactions have been pushed into the block and the block is finalized, the block is ready to be signed by the producer. This involves computing a signature digest from the serialized contents of the block header, which includes the transaction receipts included in the block. After the block is signed with the producer’s private key, the signature digest is added to the signed block instance. This completes the block signing.
+# Active/pending finalizer policies and recent votes
+cleos -u https://mainnet.telos.net get finalizer_info
 
-#### Commit Block
-After the block is signed, it is committed to the local chain. This pushes the block to the reversible block database (see Network Peer Protocol: 2.2.3. Fork Database). This makes the block available for syncing with other nodes for validation (see the Network Peer Protocol for more information about block syncing).
+# Producer schedule
+cleos -u https://mainnet.telos.net get schedule
+```
 
-#### Block Validation
-Block validation is a fundamental operation necessary to reach consensus within an Antelope blockchain. During block validation, producers receive incoming blocks from other peers and confirm the transactions included within each block. Block validation is about reaching enough quorum among active producers to agree upon:
-
-- The integrity of the block and the transactions it contains.
-- The deterministic, chronological order of transactions within each block.
-The first step towards validating a block begins when a block is received by a node. At this point, some safety checks are performed on the block. If the block does not link to an already known block or it matches the block ID of any block already received and processed by the node, the block is discarded. If the block is new, it is pushed to the chain controller for processing.
-
-#### Push Block
-When the block is received by the chain controller, the software must determine where to add the block within the local chain. The fork database, or Fork DB for short, is used for this purpose. The fork database holds all the branches with reversible blocks that have been received but are not yet finalized. To that end, the following steps are performed:
-
-1. Add block to the fork database.
-2. If block is added to the main branch that contains the current head block, apply block; or
-
-3. If block must be added to a different branch, then:
-
-    - if that branch now becomes the preferred branch compared to the current main branch: rewind all blocks up to the nearest common ancestor (and rollback the database state in the process), re-apply all blocks in the different branch, add the new block and apply it. That branch now becomes the new main branch.
-    - otherwise: add the new block to that branch in the fork database but do nothing else.
-
-
-In order for the block to be added to fork database, some block validation must occur. Block header validation must always be done before adding a block to the fork database. And if the block must be applied, some validation of the transactions within the block must occur. The degree to which transactions are validated depends on the validation mode that nodeos is configured with. Two block validation modes are supported: full validation (the default mode), and light validation.
-#### Full Validation
-In full validation mode, every transaction that is applied is fully validated. This includes verifying the signatures on the transaction and checking authorizations.
-#### Light Validation
-In light validation mode, blocks signed by trusted producers (which can be configured locally per node) can skip some of the transaction validation done during full validation. For example, signature verification is skipped and all claimed authorizations on actions are assumed to be valid.
-
-#### Block Finality
-Block finality is the final outcome of Antelope consensus. It is achieved after a supermajority of active producers have validated the block according to the consensus rules (see 3.1. Layer 1: Telos Zero Consensus (aBFT)). Blocks that reach finality are permanently recorded in the blockchain and cannot be undone. In this regard, the last irreversible block (LIB) in the chain refers to the most recent block that has become final. Therefore, from that point backwards the transactions that have been recorded on the blockchain cannot be reversed, tampered, or erased.
-
-#### Goal of Finality
-The main point of finality is to give users confidence that transactions that were applied prior and up to the LIB block cannot be modified, rolled back, or dropped. The LIB block can also be useful for active nodes to determine quickly and efficiently which branch to build off from, regardless of which is the longest one. This is because a given branch might be longer without containing the most recent LIB, in which case a shorter branch with the most recent LIB must be selected.
+Public RPC state can show schedules, policies, and tracked votes. It cannot prove a BP's private key custody, relay topology, configured vote threads, or local `safety.dat` continuity.


### PR DESCRIPTION
## Summary

- replace the legacy Leap-era BP installation, requirements, and setup guidance with a TelosZero Core post-Savanna runbook
- add an end-to-end finalizer operations guide covering BLS key creation, registration, policy and vote verification, relays, backups, rotation, failover, recovery, and decommissioning
- document the safety boundary around unique BLS keys and persistent, host-local `safety.dat`
- update node-role, `nodeos`, consensus, API, SHiP, and exchange guidance to assume instant finality is already active
- remove or warn against obsolete and unsafe configuration such as `chain-id`, `history_plugin`, stale production, wildcard CORS, and public producer services
- link the operator documentation to the maintained `telosnetwork/node-template` profiles and tooling

## Why

The existing documentation mixed older Leap and pre-Savanna instructions with the current TelosZero operating model. It did not provide BPs with the finalizer configuration and lifecycle procedures required after instant finality activation.

A producer is not operationally ready without a correctly configured BLS key, durable safety state, vote-capable relay paths, and verified on-chain policy and voting status.

## Impact

BPs now have a complete steady-state setup and recovery path for block production and finalizer voting. Non-producing operators get distinct relay, read-only API, and SHiP guidance without unnecessary signing keys.

This changes documentation only; it does not change chain or application behavior.

## Validation

- full Docusaurus production build
- `git diff --check`
- manual review of internal routes, configuration examples, role boundaries, and node-template integration

The production build succeeds with existing broken-link and broken-anchor warnings on unrelated EVM, quickstart, TEVMC, and wallet pages. None are introduced by this PR.

## Dependency

Merge telosnetwork/node-template#36 first, or alongside this PR, because these guides reference its new profiles, renderer, peer tooling, and systemd service.
